### PR TITLE
Following and modifying Transforms - fixes #2 fixes #3 fixes #4

### DIFF
--- a/Prefabs/[UnityXRCameraRig]/[UnityXRCameraRig].prefab
+++ b/Prefabs/[UnityXRCameraRig]/[UnityXRCameraRig].prefab
@@ -124,7 +124,7 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1467290445770872}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -266,7 +266,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Device: 1
-  m_PoseSource: 4
+  m_PoseSource: 5
   m_TrackingType: 0
   m_UpdateType: 0
   m_UseRelativeTransform: 1

--- a/Scripts/Data.meta
+++ b/Scripts/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 006f01dad4745e145b283336d5071746
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Attribute.meta
+++ b/Scripts/Data/Attribute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22b44ed2033ffb3428c76bb1dfbf3ac3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Attribute/Editor.meta
+++ b/Scripts/Data/Attribute/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48ac7a90a54dd4b49ab90783d8c60766
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Attribute/Editor/UnityFlagDrawer.cs
+++ b/Scripts/Data/Attribute/Editor/UnityFlagDrawer.cs
@@ -1,0 +1,14 @@
+﻿namespace VRTK.Core.Data.Attribute
+{
+    using UnityEngine;
+    using UnityEditor;
+
+    [CustomPropertyDrawer(typeof(UnityFlag))]
+    public class UnityFlagDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect _position, SerializedProperty _property, GUIContent _label)
+        {
+            _property.intValue = EditorGUI.MaskField(_position, _label, _property.intValue, _property.enumNames);
+        }
+    }
+}

--- a/Scripts/Data/Attribute/Editor/UnityFlagDrawer.cs.meta
+++ b/Scripts/Data/Attribute/Editor/UnityFlagDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 209a2137c32275248a8e09e6e976c727
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Attribute/UnityFlag.cs
+++ b/Scripts/Data/Attribute/UnityFlag.cs
@@ -1,0 +1,11 @@
+﻿namespace VRTK.Core.Data.Attribute
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The UnityFlag is an empty class that allows for a custom editor drawer.
+    /// </summary>
+    public class UnityFlag : PropertyAttribute
+    {
+    }
+}

--- a/Scripts/Data/Attribute/UnityFlag.cs.meta
+++ b/Scripts/Data/Attribute/UnityFlag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 211c7771a0840b04ab0f2d11942ecc28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Enum.meta
+++ b/Scripts/Data/Enum.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5970875ade66d02408ebb354aa2b3c24
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Enum/TransformProperties.cs
+++ b/Scripts/Data/Enum/TransformProperties.cs
@@ -1,0 +1,24 @@
+﻿namespace VRTK.Core.Data.Enum
+{
+    using System;
+
+    /// <summary>
+    /// The TransformProperties is an enum collection of properties of a transform.
+    /// </summary>
+    [Flags]
+    public enum TransformProperties
+    {
+        /// <summary>
+        /// The Position of a transform.
+        /// </summary>
+        Position = 1 << 0,
+        /// <summary>
+        /// The Rotation of a transform.
+        /// </summary>
+        Rotation = 1 << 1,
+        /// <summary>
+        /// The Scale of a transform.
+        /// </summary>
+        Scale = 1 << 2
+    }
+}

--- a/Scripts/Data/Enum/TransformProperties.cs.meta
+++ b/Scripts/Data/Enum/TransformProperties.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41e50422dbc3c344994a71ca050e9086
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Type.meta
+++ b/Scripts/Data/Type.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b4d7626aff06434b946d17b53f9903d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Type/Editor.meta
+++ b/Scripts/Data/Type/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b8ecce2168510d6419ea95d37462d136
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Type/Editor/Vector3StateDrawer.cs
+++ b/Scripts/Data/Type/Editor/Vector3StateDrawer.cs
@@ -1,0 +1,43 @@
+﻿namespace VRTK.Core.Data.Type
+{
+    using UnityEngine;
+    using UnityEditor;
+    using VRTK.Core.Utility;
+
+    [CustomPropertyDrawer(typeof(Vector3State))]
+    public class Vector3StateDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            TooltipAttribute currentTooltip = EditorHelper.GetTooltipAttribute(fieldInfo);
+            label.tooltip = (currentTooltip != null ? currentTooltip.tooltip : "");
+            SerializedProperty xState = property.FindPropertyRelative("xState");
+            SerializedProperty yState = property.FindPropertyRelative("yState");
+            SerializedProperty zState = property.FindPropertyRelative("zState");
+
+            int indent = EditorGUI.indentLevel;
+            EditorGUI.indentLevel = 0;
+            position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+            float updatePositionX = position.x;
+            float labelWidth = 15f;
+            float fieldWidth = (position.width / 3f) - labelWidth;
+
+            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "X");
+            updatePositionX += labelWidth;
+            xState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), xState.boolValue);
+            updatePositionX += fieldWidth;
+
+            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Y");
+            updatePositionX += labelWidth;
+            yState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), yState.boolValue);
+            updatePositionX += fieldWidth;
+
+            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Z");
+            updatePositionX += labelWidth;
+            zState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), zState.boolValue);
+            updatePositionX += fieldWidth;
+
+            EditorGUI.indentLevel = indent;
+        }
+    }
+}

--- a/Scripts/Data/Type/Editor/Vector3StateDrawer.cs.meta
+++ b/Scripts/Data/Type/Editor/Vector3StateDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8eb2fce68d3d7e54080327bbb63156ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Type/Vector3State.cs
+++ b/Scripts/Data/Type/Vector3State.cs
@@ -1,0 +1,47 @@
+﻿namespace VRTK.Core.Data.Type
+{
+    using System;
+
+    /// <summary>
+    /// The Vector3State DataType allows a boolean to be set per Vector3 element to provide a state reference.
+    /// </summary>
+    [Serializable]
+    public class Vector3State
+    {
+        /// <summary>
+        /// The X State of the Vector3.
+        /// </summary>
+        public bool xState;
+        /// <summary>
+        /// The Y State of the Vector3.
+        /// </summary>
+        public bool yState;
+        /// <summary>
+        /// The Z State of the Vector3.
+        /// </summary>
+        public bool zState;
+
+        /// <summary>
+        /// Default Vector3State of all false.
+        /// </summary>
+        public static readonly Vector3State False = new Vector3State(false, false, false);
+
+        /// <summary>
+        /// Default Vector3State of all true.
+        /// </summary>
+        public static readonly Vector3State True = new Vector3State(true, true, true);
+
+        /// <summary>
+        /// The Constructor that allows setting the individual states at instantiation.
+        /// </summary>
+        /// <param name="x">The X State.</param>
+        /// <param name="y">The Y State.</param>
+        /// <param name="z">The Z State.</param>
+        public Vector3State(bool x, bool y, bool z)
+        {
+            xState = x;
+            yState = y;
+            zState = z;
+        }
+    }
+}

--- a/Scripts/Data/Type/Vector3State.cs.meta
+++ b/Scripts/Data/Type/Vector3State.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 811b2ae45a2e2014a84eeb235e053970
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Extension.meta
+++ b/Scripts/Extension.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 91770398c7504ad41bba79e2a3105090
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Extension/ComponentExtensions.cs
+++ b/Scripts/Extension/ComponentExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace VRTK.Core.Extension
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The ComponentExtensions provide extended methods for the Component Type.
+    /// </summary>
+    public static class ComponentExtensions
+    {
+        /// <summary>
+        /// The TryGetTransform method attempts to retrieve the Transform from a given Component.
+        /// </summary>
+        /// <param name="component">The Component to retrieve the Transform from.</param>
+        /// <returns>A Transform if one exists on the given Component.</returns>
+        public static Transform TryGetTransform(this Component component)
+        {
+            return (component == null ? null : component.transform);
+        }
+    }
+}

--- a/Scripts/Extension/ComponentExtensions.cs.meta
+++ b/Scripts/Extension/ComponentExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c455d057337690043929b3f2d3525d64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Process.meta
+++ b/Scripts/Process.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4114bdddd99bf0d4d8806feb41ed3fb3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Process/IProcessable.cs
+++ b/Scripts/Process/IProcessable.cs
@@ -1,0 +1,10 @@
+﻿namespace VRTK.Core.Process
+{
+    /// <summary>
+    /// The IProcessable interface denotes that the target will run a Process.
+    /// </summary>
+    public interface IProcessable
+    {
+        void Process();
+    }
+}

--- a/Scripts/Process/IProcessable.cs.meta
+++ b/Scripts/Process/IProcessable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 846d6f2734b9751458170f68227630a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Process/MomentProcess.cs
+++ b/Scripts/Process/MomentProcess.cs
@@ -1,0 +1,17 @@
+﻿namespace VRTK.Core.Process
+{
+    using UnityEngine;
+    using System;
+
+    /// <summary>
+    /// The MomentProcess is a wrapper for an IProcessable process that has a state to determine when it is to be processed.
+    /// </summary>
+    public sealed class MomentProcess : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("The process to attach to the moment.")]
+        public ProcessContainer process;
+        [Tooltip("Only run the process if the process is on an active GameObject and the component is enabled.")]
+        public bool onlyProcessOnActiveAndEnabled = true;
+    }
+}

--- a/Scripts/Process/MomentProcess.cs.meta
+++ b/Scripts/Process/MomentProcess.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a11862926720f544fb5d904995c2b57b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Process/MomentProcessor.cs
+++ b/Scripts/Process/MomentProcessor.cs
@@ -1,0 +1,154 @@
+﻿namespace VRTK.Core.Process
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The MomentProcessor loops through the given moments and executes their Process method on the given Unity game loop moment.
+    /// </summary>
+    public class MomentProcessor : MonoBehaviour
+    {
+        /// <summary>
+        /// The Moment is the point in the Unity game loop when to execute the processes.
+        /// </summary>
+        public enum Moment
+        {
+            /// <summary>
+            /// Never execute the processes.
+            /// </summary>
+            None,
+            /// <summary>
+            /// Execute the processes in the FixedUpdate physics part of the Unity game loop.
+            /// </summary>
+            FixedUpdate,
+            /// <summary>
+            /// Executes the processes in the Update game logic part of the Unity game loop.
+            /// </summary>
+            Update,
+            /// <summary>
+            /// Executes the processes in the LateUpdate game logic part of the Unity game loop.
+            /// </summary>
+            LateUpdate,
+            /// <summary>
+            /// Executes the processes in the camera PreCull scene rendering part of the Unity game loop.
+            /// </summary>
+            PreCull,
+            /// <summary>
+            /// Executes the processes in the camera PreRender scene rendering part of the Unity game loop.
+            /// </summary>
+            PreRender
+        }
+
+        [Tooltip("The moment in which to process the given processes.")]
+        public Moment momentToProcess = Moment.PreRender;
+        [Tooltip("A collection of Moments to process.")]
+        public MomentProcess[] processes = new MomentProcess[0];
+
+        protected Moment subscribedMoment;
+
+        protected virtual void OnEnable()
+        {
+            subscribedMoment = Moment.None;
+            ManageSubscriptions();
+        }
+
+        protected virtual void OnDisable()
+        {
+            UnsubscribeMoment();
+        }
+
+        protected virtual void FixedUpdate()
+        {
+            if (momentToProcess == Moment.FixedUpdate)
+            {
+                Process();
+            }
+        }
+
+        protected virtual void Update()
+        {
+            if (momentToProcess == Moment.Update)
+            {
+                Process();
+            }
+        }
+
+        protected virtual void LateUpdate()
+        {
+            if (momentToProcess == Moment.LateUpdate)
+            {
+                Process();
+            }
+            ManageSubscriptions();
+        }
+
+        protected virtual void OnCameraPreRender(Camera givenCamera)
+        {
+            Process();
+        }
+
+        protected virtual void OnCameraPreCull(Camera givenCamera)
+        {
+            Process();
+        }
+
+        /// <summary>
+        /// The ManageSubscriptions method handles subscribing and unsubscribing to the relevant camera events.
+        /// </summary>
+        protected virtual void ManageSubscriptions()
+        {
+            if (subscribedMoment != momentToProcess)
+            {
+                UnsubscribeMoment();
+                SubscribeMoment();
+            }
+        }
+
+        /// <summary>
+        /// The UnsubscribeMoment method handles unsubscribing to the chosen subscribed moment event.
+        /// </summary>
+        protected virtual void UnsubscribeMoment()
+        {
+            switch (subscribedMoment)
+            {
+                case Moment.PreRender:
+                    Camera.onPreRender -= OnCameraPreRender;
+                    break;
+                case Moment.PreCull:
+                    Camera.onPreCull -= OnCameraPreCull;
+                    break;
+            }
+            subscribedMoment = Moment.None;
+        }
+
+        /// <summary>
+        /// The SubscribeMoment method handles subscribing to the chosen moment to process event.
+        /// </summary>
+        protected virtual void SubscribeMoment()
+        {
+            switch (momentToProcess)
+            {
+                case Moment.PreRender:
+                    Camera.onPreRender += OnCameraPreRender;
+                    break;
+                case Moment.PreCull:
+                    Camera.onPreCull -= OnCameraPreCull;
+                    break;
+            }
+            subscribedMoment = momentToProcess;
+        }
+
+        /// <summary>
+        /// The Process method iterates through the given processes and calls the Process method on each one.
+        /// </summary>
+        protected virtual void Process()
+        {
+            foreach (MomentProcess currentProcess in processes)
+            {
+                if (currentProcess != null && (!currentProcess.onlyProcessOnActiveAndEnabled || currentProcess.isActiveAndEnabled))
+                {
+                    currentProcess.process.Interface.Process();
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Process/MomentProcessor.cs.meta
+++ b/Scripts/Process/MomentProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c0eab237e25807459af1c5caf4d3d33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Process/ProcessContainer.cs
+++ b/Scripts/Process/ProcessContainer.cs
@@ -1,0 +1,13 @@
+﻿namespace VRTK.Core.Process
+{
+    using System;
+    using VRTK.Core.Utility;
+
+    /// <summary>
+    /// The ProcessContainer is the proxy class used to make a process interface appear in the Unity Inspector.
+    /// </summary>
+    [Serializable]
+    public sealed class ProcessContainer : InterfaceContainer<IProcessable>
+    {
+    }
+}

--- a/Scripts/Process/ProcessContainer.cs.meta
+++ b/Scripts/Process/ProcessContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13be191d3590254448111cd53fc3e72c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Process/SourceTargetProcessor.cs
+++ b/Scripts/Process/SourceTargetProcessor.cs
@@ -1,0 +1,64 @@
+﻿namespace VRTK.Core.Process
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The SourceTargetProcessor implements a Process that runs a set method on a source Component against an array of target Components.
+    /// </summary>
+    public abstract class SourceTargetProcessor : MonoBehaviour, IProcessable
+    {
+        [Header("Processor Component Settings")]
+
+        [Tooltip("The source component to apply against the source within the process.")]
+        public Component sourceComponent;
+        [Tooltip("The target components to apply the source to within the process.")]
+        public Component[] targetComponents;
+
+        /// <summary>
+        /// Tjhe Component that is currently the active target for the process.
+        /// </summary>
+        public Component ActiveTargetComponent
+        {
+            get;
+            protected set;
+        }
+
+        /// <summary>
+        /// The Process method executes the relevant process to apply between the source and target Component.
+        /// </summary>
+        public abstract void Process();
+
+        protected abstract void ProcessComponent(Component source, Component target);
+
+        /// <summary>
+        /// The ProcessAllComponents method processes the source Component against every target Component in the array.
+        /// </summary>
+        protected virtual void ProcessAllComponents()
+        {
+            foreach (Component currentComponent in targetComponents)
+            {
+                if (sourceComponent != null)
+                {
+                    ProcessComponent(sourceComponent, currentComponent);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The ProcessFirstActiveComponent method processes the source Component against the first active target Component in the array.
+        /// </summary>
+        protected virtual void ProcessFirstActiveComponent()
+        {
+            ActiveTargetComponent = null;
+            foreach (Component currentComponent in targetComponents)
+            {
+                if (sourceComponent != null && currentComponent.gameObject.activeInHierarchy)
+                {
+                    ProcessComponent(sourceComponent, currentComponent);
+                    ActiveTargetComponent = currentComponent;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Process/SourceTargetProcessor.cs.meta
+++ b/Scripts/Process/SourceTargetProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb616beb77aa3c649bb2718953eb640b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/Follow.meta
+++ b/Scripts/Tracking/Follow.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bb5112fea22cad488af11459c61b316
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/Follow/Modifier.meta
+++ b/Scripts/Tracking/Follow/Modifier.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 011df8736401e70438d35a486b3118d3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/Follow/Modifier/FollowModifier.cs
+++ b/Scripts/Tracking/Follow/Modifier/FollowModifier.cs
@@ -1,0 +1,46 @@
+﻿namespace VRTK.Core.Tracking.Follow.Modifier
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The FollowModifier provides a way of describing logic to modify a Transform's position, rotation and scale.
+    /// </summary>
+    public abstract class FollowModifier : MonoBehaviour
+    {
+        /// The current source being used in the modifier process.
+        public Transform CachedSource
+        {
+            get;
+            protected set;
+        }
+
+        /// The current target being used in the modifier process.
+        public Transform CachedTarget
+        {
+            get;
+            protected set;
+        }
+
+        /// <summary>
+        /// The ProcessFirstAndActiveOnly method determines whether the FollowModifier should process all targets or just the first active target.
+        /// </summary>
+        /// <returns>Returns `true` if only the first active target should be processed.</returns>
+        public abstract bool ProcessFirstAndActiveOnly();
+        /// <summary>
+        /// The UpdatePosition method attempts to update the source position based on the target position.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilise in the modification.</param>
+        public abstract void UpdatePosition(Transform source, Transform target);
+        /// The UpdateRotation method attempts to update the source rotation based on the target rotation.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilise in the modification.</param>
+        public abstract void UpdateRotation(Transform source, Transform target);
+        /// The UpdateScale method attempts to update the source scale based on the target scale.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilise in the modification.</param>
+        public abstract void UpdateScale(Transform source, Transform target);
+    }
+}

--- a/Scripts/Tracking/Follow/Modifier/FollowModifier.cs.meta
+++ b/Scripts/Tracking/Follow/Modifier/FollowModifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66a2edf60179e704a9fe544850cfaa52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/Follow/Modifier/TransformSourceFollowActiveTarget.cs
+++ b/Scripts/Tracking/Follow/Modifier/TransformSourceFollowActiveTarget.cs
@@ -1,0 +1,64 @@
+﻿namespace VRTK.Core.Tracking.Follow.Modifier
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The TransformSourceFollowActiveTarget will force the transformations of the source Transform to match those of the target Transform.
+    /// </summary>
+    public class TransformSourceFollowActiveTarget : FollowModifier
+    {
+        /// <summary>
+        /// The ProcessFirstAndActiveOnly method determines whether the FollowModifier should process all targets or just the first active target.
+        /// </summary>
+        /// <returns>Always returns `true`.</returns>
+        public override bool ProcessFirstAndActiveOnly()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// The UpdatePosition method attempts to set the source Transform position to the target Transform position.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilise in the modification.</param>
+        public override void UpdatePosition(Transform source, Transform target)
+        {
+            if (source != null && target != null)
+            {
+                source.position = target.position;
+            }
+            CachedSource = source;
+            CachedTarget = target;
+        }
+
+        /// <summary>
+        /// The UpdateRotation method attempts to set the source Transform rotation to the target Transform rotation.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilise in the modification.</param>
+        public override void UpdateRotation(Transform source, Transform target)
+        {
+            if (source != null && target != null)
+            {
+                source.rotation = target.rotation;
+            }
+            CachedSource = source;
+            CachedTarget = target;
+        }
+
+        /// <summary>
+        /// The UpdateScale method attempts to set the source Transform scale to the target Transform scale.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilise in the modification.</param>
+        public override void UpdateScale(Transform source, Transform target)
+        {
+            if (source != null && target != null)
+            {
+                source.localScale = target.localScale;
+            }
+            CachedSource = source;
+            CachedTarget = target;
+        }
+    }
+}

--- a/Scripts/Tracking/Follow/Modifier/TransformSourceFollowActiveTarget.cs.meta
+++ b/Scripts/Tracking/Follow/Modifier/TransformSourceFollowActiveTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e093d4d35b5601240b6061e0c9cf78d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/Follow/Modifier/TransformTargetsFollowSource.cs
+++ b/Scripts/Tracking/Follow/Modifier/TransformTargetsFollowSource.cs
@@ -1,0 +1,64 @@
+﻿namespace VRTK.Core.Tracking.Follow.Modifier
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The TransformTargetsFollowSource will force the transformations of all the target Transforms to match those of the source Transform.
+    /// </summary>
+    public class TransformTargetsFollowSource : FollowModifier
+    {
+        /// <summary>
+        /// The ProcessFirstAndActiveOnly method determines whether the FollowModifier should process all targets or just the first active target.
+        /// </summary>
+        /// <returns>Always returns `false`.</returns>
+        public override bool ProcessFirstAndActiveOnly()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// The UpdatePosition method attempts to set the target Transform position to the source Transform position.
+        /// </summary>
+        /// <param name="source">The source to utilise in the modification.</param>
+        /// <param name="target">The target to modify.</param>
+        public override void UpdatePosition(Transform source, Transform target)
+        {
+            if (source != null && target != null)
+            {
+                target.position = source.position;
+            }
+            CachedSource = source;
+            CachedTarget = target;
+        }
+
+        /// <summary>
+        /// The UpdateRotation method attempts to set the target Transform rotation to the source Transform rotation.
+        /// </summary>
+        /// <param name="source">The source to utilise in the modification.</param>
+        /// <param name="target">The target to modify.</param>
+        public override void UpdateRotation(Transform source, Transform target)
+        {
+            if (source != null && target != null)
+            {
+                target.rotation = source.rotation;
+            }
+            CachedSource = source;
+            CachedTarget = target;
+        }
+
+        /// <summary>
+        /// The UpdateScale method attempts to set the target Transform scale to the source Transform scale.
+        /// </summary>
+        /// <param name="source">The source to utilise in the modification.</param>
+        /// <param name="target">The target to modify.</param>
+        public override void UpdateScale(Transform source, Transform target)
+        {
+            if (source != null && target != null)
+            {
+                target.localScale = source.localScale;
+            }
+            CachedSource = source;
+            CachedTarget = target;
+        }
+    }
+}

--- a/Scripts/Tracking/Follow/Modifier/TransformTargetsFollowSource.cs.meta
+++ b/Scripts/Tracking/Follow/Modifier/TransformTargetsFollowSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9306261d160a01a439ea115ec06fe3ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/Follow/ObjectFollow.cs
+++ b/Scripts/Tracking/Follow/ObjectFollow.cs
@@ -1,0 +1,210 @@
+﻿namespace VRTK.Core.Tracking.Follow
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using VRTK.Core.Data.Attribute;
+    using VRTK.Core.Data.Enum;
+    using VRTK.Core.Extension;
+    using VRTK.Core.Process;
+    using VRTK.Core.Tracking.Follow.Modifier;
+
+    /// <summary>
+    /// The ObjectFollow mirrors the transform properties of another object based on the given FollowModifier.
+    /// </summary>
+    public class ObjectFollow : SourceTargetProcessor
+    {
+        [Header("Object Follow Settings")]
+
+        [UnityFlag]
+        [Tooltip("The transform properties to follow.")]
+        public TransformProperties follow = TransformProperties.Position | TransformProperties.Rotation | TransformProperties.Scale;
+        [Tooltip("The follow modifier mechanic to apply.")]
+        public FollowModifier followModifier;
+
+        /// <summary>
+        /// The ObjectFollowUnityEvent emits an event with the source Transform, target Transform and the sender object.
+        /// </summary>
+        [Serializable]
+        public class ObjectFollowUnityEvent : UnityEvent<Transform, Transform, object>
+        {
+        };
+
+        [Header("Object Follow Events")]
+
+        /// <summary>
+        /// The BeforeProcessed event is emitted before any processing.
+        /// </summary>
+        public ObjectFollowUnityEvent BeforeProcessed;
+        /// <summary>
+        /// The AfterProcessed event is emitted after all processing is complete.
+        /// </summary>
+        public ObjectFollowUnityEvent AfterProcessed;
+        /// <summary>
+        /// The BeforeTransformUpdated event is emitted before the Transform is updated.
+        /// </summary>
+        public ObjectFollowUnityEvent BeforeTransformUpdated;
+        /// <summary>
+        /// The AfterTransformUpdated event is emitted after the Transform is updated.
+        /// </summary>
+        public ObjectFollowUnityEvent AfterTransformUpdated;
+        /// <summary>
+        /// The BeforePositionUpdated event is emitted before the Transform's position is updated.
+        /// </summary>
+        public ObjectFollowUnityEvent BeforePositionUpdated;
+        /// <summary>
+        /// The AfterPositionUpdated event is emitted after the Transform's position is updated.
+        /// </summary>
+        public ObjectFollowUnityEvent AfterPositionUpdated;
+        /// <summary>
+        /// The BeforeRotationUpdated event is emitted before the Transform's rotation is updated.
+        /// </summary>
+        public ObjectFollowUnityEvent BeforeRotationUpdated;
+        /// <summary>
+        /// The AfterRotationUpdated event is emitted after the Transform's rotation is updated.
+        /// </summary>
+        public ObjectFollowUnityEvent AfterRotationUpdated;
+        /// <summary>
+        /// The BeforeScaleUpdated event is emitted before the Transform's scale is updated.
+        /// </summary>
+        public ObjectFollowUnityEvent BeforeScaleUpdated;
+        /// <summary>
+        /// The AfterScaleUpdated event is emitted after the Transform's scale is updated.
+        /// </summary>
+        public ObjectFollowUnityEvent AfterScaleUpdated;
+
+        /// <summary>
+        /// The Process method executes the relevant process on the given FollowModifier.
+        /// </summary>
+        public override void Process()
+        {
+            OnBeforeProcessed();
+            if (followModifier.ProcessFirstAndActiveOnly())
+            {
+                ProcessFirstActiveComponent();
+            }
+            else
+            {
+                ProcessAllComponents();
+            }
+            OnAfterProcessed();
+        }
+
+        protected virtual void OnBeforeProcessed()
+        {
+            BeforeProcessed?.Invoke(null, null, this);
+        }
+
+        protected virtual void OnAfterProcessed()
+        {
+            AfterProcessed?.Invoke(null, null, this);
+        }
+
+        protected virtual void OnBeforeTransformUpdated(Transform source, Transform target)
+        {
+            BeforeTransformUpdated?.Invoke(source, target, this);
+        }
+
+        protected virtual void OnAfterTransformUpdated(Transform source, Transform target)
+        {
+            AfterTransformUpdated?.Invoke(source, target, this);
+        }
+
+        protected virtual void OnBeforePositionUpdated(Transform source, Transform target)
+        {
+            BeforePositionUpdated?.Invoke(source, target, this);
+        }
+
+        protected virtual void OnAfterPositionUpdated(Transform source, Transform target)
+        {
+            AfterPositionUpdated?.Invoke(source, target, this);
+        }
+
+        protected virtual void OnBeforeRotationUpdated(Transform source, Transform target)
+        {
+            BeforeRotationUpdated?.Invoke(source, target, this);
+        }
+
+        protected virtual void OnAfterRotationUpdated(Transform source, Transform target)
+        {
+            AfterRotationUpdated?.Invoke(source, target, this);
+        }
+
+        protected virtual void OnBeforeScaleUpdated(Transform source, Transform target)
+        {
+            BeforeScaleUpdated?.Invoke(source, target, this);
+        }
+
+        protected virtual void OnAfterScaleUpdated(Transform source, Transform target)
+        {
+            AfterScaleUpdated?.Invoke(source, target, this);
+        }
+
+        /// <summary>
+        /// The ProcessComponent method applies the transformations on the source Transform using the taget Transform.
+        /// </summary>
+        /// <param name="source">The source Component that is a Transform.</param>
+        /// <param name="target">The target Component that is a Transform.</param>
+        protected override void ProcessComponent(Component source, Component target)
+        {
+            Transform sourceTransform = source.TryGetTransform();
+            Transform targetTransform = target.TryGetTransform();
+
+            if (followModifier != null)
+            {
+                OnBeforeTransformUpdated(sourceTransform, targetTransform);
+
+                UpdateScale(sourceTransform, targetTransform);
+                UpdateRotation(sourceTransform, targetTransform);
+                UpdatePosition(sourceTransform, targetTransform);
+
+                OnAfterTransformUpdated(sourceTransform, targetTransform);
+            }
+        }
+
+        /// <summary>
+        /// The UpdatePosition method executes the specified FollowModifier's UpdatePosition method.
+        /// </summary>
+        /// <param name="sourceTransform">The source Transform to apply the FollowModifier on.</param>
+        /// <param name="targetTransform">The target Transform to apply the FollowModifier with.</param>
+        protected virtual void UpdatePosition(Transform sourceTransform, Transform targetTransform)
+        {
+            if (follow.HasFlag(TransformProperties.Position))
+            {
+                OnBeforePositionUpdated(sourceTransform, targetTransform);
+                followModifier.UpdatePosition(sourceTransform, targetTransform);
+                OnAfterPositionUpdated(sourceTransform, targetTransform);
+            }
+        }
+
+        /// <summary>
+        /// The UpdateRotation method executes the specified FollowModifier's UpdateRotation method.
+        /// </summary>
+        /// <param name="sourceTransform">The source Transform to apply the FollowModifier on.</param>
+        /// <param name="targetTransform">The target Transform to apply the FollowModifier with.</param>
+        protected virtual void UpdateRotation(Transform sourceTransform, Transform targetTransform)
+        {
+            if (follow.HasFlag(TransformProperties.Rotation))
+            {
+                OnBeforeRotationUpdated(sourceTransform, targetTransform);
+                followModifier.UpdateRotation(sourceTransform, targetTransform);
+                OnAfterRotationUpdated(sourceTransform, targetTransform);
+            }
+        }
+
+        /// <summary>
+        /// The UpdateScale method executes the specified FollowModifier's UpdateScale method.
+        /// </summary>
+        /// <param name="sourceTransform">The source Transform to apply the FollowModifier on.</param>
+        /// <param name="targetTransform">The target Transform to apply the FollowModifier with.</param>
+        protected virtual void UpdateScale(Transform sourceTransform, Transform targetTransform)
+        {
+            if (follow.HasFlag(TransformProperties.Scale))
+            {
+                OnBeforeScaleUpdated(sourceTransform, targetTransform);
+                followModifier.UpdateScale(sourceTransform, targetTransform);
+                OnAfterScaleUpdated(sourceTransform, targetTransform);
+            }
+        }
+    }
+}

--- a/Scripts/Tracking/Follow/ObjectFollow.cs.meta
+++ b/Scripts/Tracking/Follow/ObjectFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36b5781728bc3ef47af5d7aca57b0e57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/TransformModify.cs
+++ b/Scripts/Tracking/TransformModify.cs
@@ -1,0 +1,283 @@
+﻿namespace VRTK.Core.Tracking
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using System.Collections;
+    using VRTK.Core.Data.Attribute;
+    using VRTK.Core.Data.Enum;
+    using VRTK.Core.Data.Type;
+
+    /// <summary>
+    /// The TransformModify applies a transformation onto a given source Trasnform based on an injected target Transform.
+    /// </summary>
+    public class TransformModify : MonoBehaviour
+    {
+        [Tooltip("The source Transform to apply the transformations to.")]
+        public Transform source;
+        [Tooltip("A Transform to use as an offset/pivot when executing the transformations.")]
+        public Transform offset;
+        [Tooltip("Determines which axes to apply on when utilising the offset.")]
+        public Vector3State applyOffsetOnAxis = new Vector3State(true, true, true);
+        [UnityFlag]
+        [Tooltip("The Transform properties to apply the transformations on.")]
+        public TransformProperties applyTransformations = TransformProperties.Position | TransformProperties.Rotation | TransformProperties.Scale;
+        [Tooltip("The amount of time to take when transitioning from the current Transform state to the modified Transform state.")]
+        public float transitionDuration = 0f;
+
+        /// <summary>
+        /// The TransformModifyUnityEvent emits an event with the source Transform, target Transform and the sender object.
+        /// </summary>
+        [Serializable]
+        public class TransformModifyUnityEvent : UnityEvent<Transform, Transform, object>
+        {
+        };
+
+        /// <summary>
+        /// The BeforeTransformUpdated event is emitted before the transformation process occurs.
+        /// </summary>
+        public TransformModifyUnityEvent BeforeTransformUpdated;
+        /// <summary>
+        /// The AfterTransformUpdated event is emitted after the transformation process has occured.
+        /// </summary>
+        public TransformModifyUnityEvent AfterTransformUpdated;
+
+        protected Vector3 finalPosition;
+        protected Quaternion finalRotation;
+        protected Vector3 finalScale;
+        protected Coroutine transitionRoutine;
+
+        /// <summary>
+        /// The Modify method attempts to apply the properties of the target Transform to the source Transform.
+        /// </summary>
+        /// <param name="target">The target Transform to obtain the transformation properties from.</param>
+        /// <param name="initiator">Tne object that initiated the modification.</param>
+        public virtual void Modify(Transform target, object initiator = null)
+        {
+            if (source != null && target != null)
+            {
+                OnBeforeTransformUpdated(source, target);
+                SetScale(source, target);
+                SetPosition(source, target);
+                SetRotation(source, target);
+                ProcessTransform(source);
+                OnAfterTransformUpdated(source, target);
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            CancelTransition();
+        }
+
+        protected virtual void OnBeforeTransformUpdated(Transform givenSource, Transform givenTarget)
+        {
+            BeforeTransformUpdated?.Invoke(givenSource, givenTarget, this);
+        }
+
+        protected virtual void OnAfterTransformUpdated(Transform givenSource, Transform givenTarget)
+        {
+            AfterTransformUpdated?.Invoke(givenSource, givenTarget, this);
+        }
+
+        /// <summary>
+        /// The ProcessTransform method takes a given Transform source and attempts to apply the final transformations to it.
+        /// </summary>
+        /// <param name="givenSource">The source Transform to apply transformations to.</param>
+        protected virtual void ProcessTransform(Transform givenSource)
+        {
+            if (transitionDuration == 0f)
+            {
+                givenSource.localScale = finalScale;
+                givenSource.position = finalPosition;
+                givenSource.rotation = finalRotation;
+            }
+            else
+            {
+                CancelTransition();
+                transitionRoutine = StartCoroutine(TransitionTransform(givenSource, givenSource.position, finalPosition, givenSource.rotation, finalRotation, givenSource.localScale, finalScale));
+            }
+        }
+
+        /// <summary>
+        /// The SetPosition method attempts to calculate the final position to apply based on the given target Transform.
+        /// </summary>
+        /// <param name="givenSource">The source Transform that will have the position transformations applied to.</param>
+        /// <param name="target">The target Transform that will be used to determine the position transformation that is to be applied.</param>
+        protected virtual void SetPosition(Transform givenSource, Transform target)
+        {
+            finalPosition = givenSource.position;
+            if (applyTransformations.HasFlag(TransformProperties.Position))
+            {
+                finalPosition = CalculatePosition(givenSource, target.position, target.rotation, finalScale);
+            }
+        }
+
+        /// <summary>
+        /// The SetRotation method attempts to calculate the final rotation to apply based on the given target Transform.
+        /// </summary>
+        /// <param name="givenSource">The source Transform that will have the rotation transformations applied to.</param>
+        /// <param name="target">The target Transform that will be used to determine the rotation transformation that is to be applied.</param>
+        protected virtual void SetRotation(Transform givenSource, Transform target)
+        {
+            finalRotation = givenSource.rotation;
+            if (applyTransformations.HasFlag(TransformProperties.Rotation))
+            {
+                SetPositionWithOriginToSource(givenSource, target);
+                finalRotation = target.rotation;
+            }
+        }
+
+        /// <summary>
+        /// The SetScale method attempts to calculate the final scale to apply based on the given target Transform.
+        /// </summary>
+        /// <param name="givenSource">The source Transform that will have the scale transformations applied to.</param>
+        /// <param name="target">The target Transform that will be used to determine the scale transformation that is to be applied.</param>
+        protected virtual void SetScale(Transform givenSource, Transform target)
+        {
+            finalScale = givenSource.localScale;
+            if (applyTransformations.HasFlag(TransformProperties.Scale))
+            {
+                finalScale = target.localScale;
+            }
+        }
+
+        /// <summary>
+        /// The SetPositionWithOriginToSource method attempts to calculate the final position when the source Transform also has an origin Transform.
+        /// </summary>
+        /// <param name="givenSource">The source Transform that will have the position transformations applied to.</param>
+        /// <param name="target">The target Transform that will be used to determine the position transformation that is to be applied.</param>
+        protected virtual void SetPositionWithOriginToSource(Transform givenSource, Transform target)
+        {
+            if (!applyTransformations.HasFlag(TransformProperties.Position) && offset != null)
+            {
+                target.position = GetModifiedPosition(givenSource);
+                finalPosition = CalculatePosition(givenSource, target.position, target.rotation, finalScale);
+            }
+        }
+
+        /// <summary>
+        /// The CalculatePosition method attempts to calculate the position of a Transform based on the target position, rotation and scale.
+        /// </summary>
+        /// <param name="givenSource">The source Transform that will have the position transformations applied to.</param>
+        /// <param name="targetPosition">The target position value.</param>
+        /// <param name="targetRotation">The target rotation value.</param>
+        /// <param name="targetScale">The target scale value.</param>
+        /// <returns>A Vector3 of the calculated final position.</returns>
+        protected virtual Vector3 CalculatePosition(Transform givenSource, Vector3 targetPosition, Quaternion targetRotation, Vector3 targetScale)
+        {
+            if (offset == null)
+            {
+                return targetPosition;
+            }
+
+            if (!applyTransformations.HasFlag(TransformProperties.Rotation))
+            {
+                return GetOffsetPosition(givenSource.position, targetPosition, offset.position);
+            }
+
+            Vector3 calculatedOffset = GetOffsetPosition(givenSource.position, Vector3.zero, offset.position) * -1f;
+            Quaternion relativeRotation = Quaternion.Inverse(givenSource.rotation) * targetRotation;
+            Vector3 adjustedOffset = relativeRotation * calculatedOffset;
+            Vector3 scaleFactor = new Vector3(targetScale.x / givenSource.localScale.x, targetScale.y / givenSource.localScale.y, targetScale.z / givenSource.localScale.z);
+            Vector3 scaledOffset = Vector3.Scale(adjustedOffset, scaleFactor);
+            return targetPosition - scaledOffset;
+        }
+
+        /// <summary>
+        /// The GetModifiedPosition retrieves the modified position with any relevant offset requirements applied.
+        /// </summary>
+        /// <param name="givenSource">The source Transform that will have the position transformations applied to.</param>
+        /// <returns>A Vector3 of the modified position taking in to consideration any offset transformations.</returns>
+        protected virtual Vector3 GetModifiedPosition(Transform givenSource)
+        {
+            return new Vector3(
+                GetModifiedPositionValue(applyOffsetOnAxis.xState, offset.position.x, givenSource.position.x),
+                GetModifiedPositionValue(applyOffsetOnAxis.yState, offset.position.y, givenSource.position.y),
+                GetModifiedPositionValue(applyOffsetOnAxis.zState, offset.position.z, givenSource.position.z)
+                );
+        }
+
+        /// <summary>
+        /// The GetModifiedPositionValue method returns the relevant modified position value between either the source or the target position.
+        /// </summary>
+        /// <param name="useTargetValue">Determines whether to utilise the target value.</param>
+        /// <param name="targetValue">The target value to apply.</param>
+        /// <param name="sourceValue">The source value to apply.</param>
+        /// <returns>A float of the modified position which is either the given `targetValue` or given `sourceValue`.</returns>
+        protected virtual float GetModifiedPositionValue(bool useTargetValue, float targetValue, float sourceValue)
+        {
+            return (useTargetValue ? targetValue : sourceValue);
+        }
+
+        /// <summary>
+        /// The GetOffsetPosition method returns the position with the appropriate offset. 
+        /// </summary>
+        /// <param name="sourcePosition">The source Transform current position.</param>
+        /// <param name="targetPosition">The target Transform current position.</param>
+        /// <param name="offsetPosition">The offset Transform current position.</param>
+        /// <returns>A Vector3 of the Transform position with the applied offset.</returns>
+        protected virtual Vector3 GetOffsetPosition(Vector3 sourcePosition, Vector3 targetPosition, Vector3 offsetPosition)
+        {
+            float xPosition = GetOffsetCoordinate(applyOffsetOnAxis.xState, sourcePosition, targetPosition, offsetPosition, 0);
+            float yPosition = GetOffsetCoordinate(applyOffsetOnAxis.yState, sourcePosition, targetPosition, offsetPosition, 1);
+            float zPosition = GetOffsetCoordinate(applyOffsetOnAxis.zState, sourcePosition, targetPosition, offsetPosition, 2);
+            return new Vector3(xPosition, yPosition, zPosition);
+        }
+
+        /// <summary>
+        /// The GetOffsetCoordinate method retrieves the offset position coordinate.
+        /// </summary>
+        /// <param name="applyOffset">Determines whether to apply the offset position to the calculation.</param>
+        /// <param name="sourcePosition">The source position to use within the calculation.</param>
+        /// <param name="targetPosition">The target position to use within the calculation.</param>
+        /// <param name="offsetPosition">The offset position to use within the calculation.</param>
+        /// <param name="coordinate">The coordinate of the Vector3 to access.</param>
+        /// <returns>A float of the coordinate position with the applied offset.</returns>
+        protected virtual float GetOffsetCoordinate(bool applyOffset, Vector3 sourcePosition, Vector3 targetPosition, Vector3 offsetPosition, int coordinate)
+        {
+            return (applyOffset ? targetPosition[coordinate] - (offsetPosition[coordinate] - sourcePosition[coordinate]) : targetPosition[coordinate]);
+        }
+
+        /// <summary>
+        /// The CancelTransition method cancels the transition of the transformation.
+        /// </summary>
+        protected virtual void CancelTransition()
+        {
+            if (transitionRoutine != null)
+            {
+                StopCoroutine(transitionRoutine);
+            }
+        }
+
+        /// <summary>
+        /// The TransitionTransform method applies the relevant transformation to the affected Transform over a given duration.
+        /// </summary>
+        /// <param name="affectTransform">The Transform to apply the transformations to.</param>
+        /// <param name="startPosition">The initial position of the Transform.</param>
+        /// <param name="destinationPosition">The final position for the Transform.</param>
+        /// <param name="startRotation">The initial rotation of the Transform.</param>
+        /// <param name="destinationRotation">The final rotation of the Transform.</param>
+        /// <param name="startScale">The initial scale of the Transform.</param>
+        /// <param name="destinationScale">The final scale of the Transform.</param>
+        /// <returns>An Enumerator to handle the running of the coroutine.</returns>
+        protected virtual IEnumerator TransitionTransform(Transform affectTransform, Vector3 startPosition, Vector3 destinationPosition, Quaternion startRotation, Quaternion destinationRotation, Vector3 startScale, Vector3 destinationScale)
+        {
+            float elapsedTime = 0f;
+            WaitForEndOfFrame delayInstruction = new WaitForEndOfFrame();
+            while (elapsedTime < transitionDuration)
+            {
+                float lerpFrame = (elapsedTime / transitionDuration);
+                affectTransform.localScale = Vector3.Lerp(startScale, destinationScale, lerpFrame);
+                affectTransform.position = Vector3.Lerp(startPosition, destinationPosition, lerpFrame);
+                affectTransform.rotation = Quaternion.Lerp(startRotation, destinationRotation, lerpFrame);
+                elapsedTime += Time.deltaTime;
+                yield return delayInstruction;
+            }
+
+            affectTransform.localScale = destinationScale;
+            affectTransform.position = destinationPosition;
+            affectTransform.rotation = destinationRotation;
+        }
+    }
+}

--- a/Scripts/Tracking/TransformModify.cs.meta
+++ b/Scripts/Tracking/TransformModify.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2dec536a0cacdc84b84a384ca98d6493
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/Velocity/VelocityTrackerProcessor.cs
+++ b/Scripts/Tracking/Velocity/VelocityTrackerProcessor.cs
@@ -26,6 +26,7 @@
         public override Vector3 GetVelocity()
         {
             Vector3 currentVelocity = Vector3.zero;
+            cachedTracker = null;
             foreach (VelocityTracker currentTracker in velocityTrackers)
             {
                 if (currentTracker != null && currentTracker.IsActive())
@@ -45,6 +46,7 @@
         public override Vector3 GetAngularVelocity()
         {
             Vector3 currentAngularVelocity = Vector3.zero;
+            cachedTracker = null;
             foreach (VelocityTracker currentTracker in velocityTrackers)
             {
                 if (currentTracker != null && currentTracker.IsActive())
@@ -63,7 +65,7 @@
         /// <returns>A VelocityTracker that is currently active.</returns>
         public virtual VelocityTracker GetActiveVelocityTracker()
         {
-            return (cachedTracker.IsActive() ? cachedTracker : null);
+            return (cachedTracker != null && cachedTracker.IsActive() ? cachedTracker : null);
         }
     }
 }

--- a/Scripts/Utility.meta
+++ b/Scripts/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d58bc9e38d8139b4797aa3fc69cff147
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Utility/Editor.meta
+++ b/Scripts/Utility/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9f91dc0175d742429a4b2ea04755e02
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Utility/Editor/EditorHelper.cs
+++ b/Scripts/Utility/Editor/EditorHelper.cs
@@ -1,0 +1,115 @@
+﻿namespace VRTK.Core.Utility
+{
+    using UnityEngine;
+    using UnityEditor;
+    using System;
+    using System.Reflection;
+
+    /// <summary>
+    /// The EditorHelper provides a collection of common static methods for use within Editor scripts.
+    /// </summary>
+    public static class EditorHelper
+    {
+        /// <summary>
+        /// The GetTooltipAttribute method returns the [Tooltip(")] attribute for the given FieldInfo.
+        /// </summary>
+        /// <param name="fieldInfo">The FieldInfo to get the tooltip attribute from.</param>
+        /// <returns>A TooltipAttribute linked to the given FieldInfo.</returns>
+        public static TooltipAttribute GetTooltipAttribute(FieldInfo fieldInfo)
+        {
+            return (TooltipAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(TooltipAttribute));
+        }
+
+        /// <summary>
+        /// The BuildGUIContent method returns a GUIContent formatted element.
+        /// </summary>
+        /// <typeparam name="T">The type of the FieldInfo for the given field name.</typeparam>
+        /// <param name="fieldName">The name of the field to build the GUIContent for.</param>
+        /// <param name="displayOverride">An optional string to override the display text in the GUIContent.</param>
+        /// <returns>A GUIContent formatted with the appropriate field information and tooltip attribute.</returns>
+        public static GUIContent BuildGUIContent<T>(string fieldName, string displayOverride = null)
+        {
+            string displayName = (displayOverride != null ? displayOverride : ObjectNames.NicifyVariableName(fieldName));
+            FieldInfo fieldInfo = typeof(T).GetField(fieldName);
+            TooltipAttribute tooltipAttribute = GetTooltipAttribute(fieldInfo);
+            return (tooltipAttribute == null ? new GUIContent(displayName) : new GUIContent(displayName, tooltipAttribute.tooltip));
+        }
+
+        /// <summary>
+        /// The AddHeader method attempts to add a header label.
+        /// </summary>
+        /// <typeparam name="T">The type of the FieldInfo for the given field name.</typeparam>
+        /// <param name="fieldName">The name of the field to look for the header attribute from.</param>
+        /// <param name="displayOverride">An optional string to use for the display text in the header.</param>
+        public static void AddHeader<T>(string fieldName, string displayOverride = null)
+        {
+            string displayName = (displayOverride != null ? displayOverride : ObjectNames.NicifyVariableName(fieldName));
+            FieldInfo fieldInfo = typeof(T).GetField(fieldName);
+            HeaderAttribute headerAttribute = (HeaderAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(HeaderAttribute));
+            AddHeader(headerAttribute == null ? displayName : headerAttribute.header);
+        }
+
+        /// <summary>
+        /// The AddHeader method attempts to add a header label.
+        /// </summary>
+        /// <param name="header">The string for the header label.</param>
+        /// <param name="spaceBeforeHeader">Dertermines whether a line space should be added before the header.</param>
+        public static void AddHeader(string header, bool spaceBeforeHeader = true)
+        {
+            if (spaceBeforeHeader)
+            {
+                EditorGUILayout.Space();
+            }
+
+            EditorGUILayout.LabelField(header, EditorStyles.boldLabel);
+        }
+
+        /// <summary>
+        /// The DrawUsingDestructiveStyle method draws an action with a destructive style.
+        /// </summary>
+        /// <param name="styleToCopy">The GUIStyle to copy the style from.</param>
+        /// <param name="drawAction">The Action to draw the style with.</param>
+        public static void DrawUsingDestructiveStyle(GUIStyle styleToCopy, Action<GUIStyle> drawAction)
+        {
+            Color previousBackgroundColor = GUI.backgroundColor;
+            GUIStyle destructiveButtonStyle = new GUIStyle(styleToCopy)
+            {
+                normal =
+                {
+                    textColor = Color.white
+                },
+                active =
+                {
+                    textColor = Color.white
+                }
+            };
+
+            GUI.backgroundColor = Color.red;
+            drawAction(destructiveButtonStyle);
+            GUI.backgroundColor = previousBackgroundColor;
+        }
+
+        /// <summary>
+        /// The DrawScrollableSelectableLabel method attempts to draw a selectable label that is also scrollable.
+        /// </summary>
+        /// <param name="scrollPosition">The current scroll position of the label element.</param>
+        /// <param name="width">The width of the label element.</param>
+        /// <param name="text">The text to display within the label element.</param>
+        /// <param name="style">The GUIStyle to draw the label with.</param>
+        public static void DrawScrollableSelectableLabel(ref Vector2 scrollPosition, ref float width, string text, GUIStyle style)
+        {
+            using (EditorGUILayout.ScrollViewScope scrollViewScope = new EditorGUILayout.ScrollViewScope(scrollPosition))
+            {
+                scrollPosition = scrollViewScope.scrollPosition;
+
+                float textHeight = style.CalcHeight(new GUIContent(text), width);
+                EditorGUILayout.SelectableLabel(text, style, GUILayout.MinHeight(textHeight));
+
+                if (Event.current.type == EventType.Repaint)
+                {
+                    width = GUILayoutUtility.GetLastRect().width;
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Utility/Editor/EditorHelper.cs.meta
+++ b/Scripts/Utility/Editor/EditorHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86b741a6f438393408c1334171dfafd3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Utility/Editor/InterfaceContainerDrawer.cs
+++ b/Scripts/Utility/Editor/InterfaceContainerDrawer.cs
@@ -1,0 +1,37 @@
+﻿namespace VRTK.Core.Utility
+{
+    using UnityEngine;
+    using UnityEditor;
+    using System;
+    using System.Linq;
+
+    [CustomPropertyDrawer(typeof(InterfaceContainer), true)]
+    public class InterfaceContainerDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            // TODO: Cache the generic type lookup per `property`.
+            Type type = fieldInfo.FieldType;
+            if (type.HasElementType)
+            {
+                type = type.GetElementType();
+            }
+
+            while (type != null && type.BaseType != typeof(InterfaceContainer))
+            {
+                type = type.BaseType;
+            }
+
+            if (type?.BaseType != typeof(InterfaceContainer))
+            {
+                // TODO: Support List<> and others somehow. See the above -> Unity is calling this PropertyDrawer even if the actual type we're supporting with it is just part of something... Probably just needs to use something else than `fieldInfo` or something...
+                throw new ArgumentException();
+            }
+
+            using (new EditorGUI.PropertyScope(position, label, property))
+            {
+                EditorGUI.ObjectField(position, property.FindPropertyRelative("field"), type.GenericTypeArguments.Single());
+            }
+        }
+    }
+}

--- a/Scripts/Utility/Editor/InterfaceContainerDrawer.cs.meta
+++ b/Scripts/Utility/Editor/InterfaceContainerDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dbf57715140b414191e4841bfbdf418
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Utility/InterfaceContainer.cs
+++ b/Scripts/Utility/InterfaceContainer.cs
@@ -1,0 +1,43 @@
+﻿namespace VRTK.Core.Utility
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The InterfaceContainer acts as a container for an object that implements an interface that can be utilized within a Unity Inspector.
+    /// </summary>
+    public abstract class InterfaceContainer
+    {
+        [SerializeField]
+        protected Object field;
+    }
+
+    /// <summary>
+    /// The InterfaceContainer acts as a container for a given interface type.
+    /// </summary>
+    /// <typeparam name="TInterface">The type of container for the interface.</typeparam>
+    public abstract class InterfaceContainer<TInterface> : InterfaceContainer
+    {
+        public TInterface Interface
+        {
+            get
+            {
+                return field == null ? _interface : (TInterface)(object)field;
+            }
+            set
+            {
+                Object @object = value as Object;
+                if (@object == null)
+                {
+                    _interface = value;
+                    field = null;
+                }
+                else
+                {
+                    field = @object;
+                    _interface = default(TInterface);
+                }
+            }
+        }
+        private TInterface _interface;
+    }
+}

--- a/Scripts/Utility/InterfaceContainer.cs.meta
+++ b/Scripts/Utility/InterfaceContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a3a7a56b289ca64baf9aba29d99fe51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Data.meta
+++ b/Tests/Editor/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c5c0bcfa1417f264e9ac760af58c6b2f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Data/Type.meta
+++ b/Tests/Editor/Data/Type.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6be1d0e7c0efd44d93b8b004dec08b4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Data/Type/Vector3StateTest.cs
+++ b/Tests/Editor/Data/Type/Vector3StateTest.cs
@@ -1,0 +1,34 @@
+﻿namespace VRTK.Core.Data.Type
+{
+    using NUnit.Framework;
+
+    public class Vector3StateTest
+    {
+        [Test]
+        public void DefaultStateTrue()
+        {
+            Vector3State actualResult = Vector3State.True;
+            Assert.IsTrue(actualResult.xState);
+            Assert.IsTrue(actualResult.yState);
+            Assert.IsTrue(actualResult.zState);
+        }
+
+        [Test]
+        public void DefaultStateFalse()
+        {
+            Vector3State actualResult = Vector3State.False;
+            Assert.IsFalse(actualResult.xState);
+            Assert.IsFalse(actualResult.yState);
+            Assert.IsFalse(actualResult.zState);
+        }
+
+        [Test]
+        public void CustomInitialState()
+        {
+            Vector3State actualResult = new Vector3State(false, true, false);
+            Assert.IsFalse(actualResult.xState);
+            Assert.IsTrue(actualResult.yState);
+            Assert.IsFalse(actualResult.zState);
+        }
+    }
+}

--- a/Tests/Editor/Data/Type/Vector3StateTest.cs.meta
+++ b/Tests/Editor/Data/Type/Vector3StateTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ac7082221e9a624caba000e19671c6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Follow.meta
+++ b/Tests/Editor/Tracking/Follow.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 453427bb1c9b4e54ba670a339bab7f96
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Follow/Modifier.meta
+++ b/Tests/Editor/Tracking/Follow/Modifier.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 462f4643a64c5a9448c9399ea3db4dfd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Follow/Modifier/TransformSourceFollowActiveTargetTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/TransformSourceFollowActiveTargetTest.cs
@@ -1,0 +1,84 @@
+﻿namespace VRTK.Core.Tracking.Follow.Modifier
+{
+    using UnityEngine;
+    using NUnit.Framework;
+
+    public class TransformSourceFollowActiveTargetTest
+    {
+        private GameObject containingObject;
+        private TransformSourceFollowActiveTarget subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<TransformSourceFollowActiveTarget>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            subject = null;
+            containingObject = null;
+        }
+
+        [Test]
+        public void ProcessFirstAndActiveOnly()
+        {
+            Assert.IsTrue(subject.ProcessFirstAndActiveOnly());
+        }
+
+        [Test]
+        public void UpdatePosition()
+        {
+            GameObject source = new GameObject();
+            GameObject target = new GameObject();
+
+            source.transform.position = Vector3.zero;
+            target.transform.position = Vector3.one;
+
+            subject.UpdatePosition(source.transform, target.transform);
+
+            Assert.AreEqual(source.transform.position, Vector3.one);
+            Assert.AreEqual(target.transform.position, Vector3.one);
+            Assert.AreEqual(source.transform, subject.CachedSource);
+            Assert.AreEqual(target.transform, subject.CachedTarget);
+        }
+
+        [Test]
+        public void UpdateRotation()
+        {
+            GameObject source = new GameObject();
+            GameObject target = new GameObject();
+
+            Quaternion targetRotation = new Quaternion(1f, 0f, 0f, 0f);
+
+            source.transform.rotation = Quaternion.identity;
+            target.transform.rotation = targetRotation;
+
+            subject.UpdateRotation(source.transform, target.transform);
+
+            Assert.AreEqual(source.transform.rotation, targetRotation);
+            Assert.AreEqual(target.transform.rotation, targetRotation);
+            Assert.AreEqual(source.transform, subject.CachedSource);
+            Assert.AreEqual(target.transform, subject.CachedTarget);
+        }
+
+        [Test]
+        public void UpdateScale()
+        {
+            GameObject source = new GameObject();
+            GameObject target = new GameObject();
+
+            source.transform.localScale = Vector3.zero;
+            target.transform.localScale = Vector3.one;
+
+            subject.UpdateScale(source.transform, target.transform);
+
+            Assert.AreEqual(source.transform.localScale, Vector3.one);
+            Assert.AreEqual(target.transform.localScale, Vector3.one);
+            Assert.AreEqual(source.transform, subject.CachedSource);
+            Assert.AreEqual(target.transform, subject.CachedTarget);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Follow/Modifier/TransformSourceFollowActiveTargetTest.cs.meta
+++ b/Tests/Editor/Tracking/Follow/Modifier/TransformSourceFollowActiveTargetTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29cc8b693bcd92a49988fffe786e576a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Follow/Modifier/TransformTargetsFollowSourceTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/TransformTargetsFollowSourceTest.cs
@@ -1,0 +1,84 @@
+﻿namespace VRTK.Core.Tracking.Follow.Modifier
+{
+    using UnityEngine;
+    using NUnit.Framework;
+
+    public class TransformTargetsFollowSourceTest
+    {
+        private GameObject containingObject;
+        private TransformTargetsFollowSource subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<TransformTargetsFollowSource>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            subject = null;
+            containingObject = null;
+        }
+
+        [Test]
+        public void ProcessAll()
+        {
+            Assert.IsFalse(subject.ProcessFirstAndActiveOnly());
+        }
+
+        [Test]
+        public void UpdatePosition()
+        {
+            GameObject source = new GameObject();
+            GameObject target = new GameObject();
+
+            source.transform.position = Vector3.one;
+            target.transform.position = Vector3.zero;
+
+            subject.UpdatePosition(source.transform, target.transform);
+
+            Assert.AreEqual(source.transform.position, Vector3.one);
+            Assert.AreEqual(target.transform.position, Vector3.one);
+            Assert.AreEqual(source.transform, subject.CachedSource);
+            Assert.AreEqual(target.transform, subject.CachedTarget);
+        }
+
+        [Test]
+        public void UpdateRotation()
+        {
+            GameObject source = new GameObject();
+            GameObject target = new GameObject();
+
+            Quaternion targetRotation = new Quaternion(1f, 0f, 0f, 0f);
+
+            source.transform.rotation = targetRotation;
+            target.transform.rotation = Quaternion.identity;
+
+            subject.UpdateRotation(source.transform, target.transform);
+
+            Assert.AreEqual(source.transform.rotation, targetRotation);
+            Assert.AreEqual(target.transform.rotation, targetRotation);
+            Assert.AreEqual(source.transform, subject.CachedSource);
+            Assert.AreEqual(target.transform, subject.CachedTarget);
+        }
+
+        [Test]
+        public void UpdateScale()
+        {
+            GameObject source = new GameObject();
+            GameObject target = new GameObject();
+
+            source.transform.localScale = Vector3.one;
+            target.transform.localScale = Vector3.zero;
+
+            subject.UpdateScale(source.transform, target.transform);
+
+            Assert.AreEqual(source.transform.localScale, Vector3.one);
+            Assert.AreEqual(target.transform.localScale, Vector3.one);
+            Assert.AreEqual(source.transform, subject.CachedSource);
+            Assert.AreEqual(target.transform, subject.CachedTarget);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Follow/Modifier/TransformTargetsFollowSourceTest.cs.meta
+++ b/Tests/Editor/Tracking/Follow/Modifier/TransformTargetsFollowSourceTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76e7d1963084a3e4bbbe2cc6d875bb95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
@@ -1,0 +1,302 @@
+﻿namespace VRTK.Core.Tracking.Follow
+{
+    using UnityEngine;
+    using NUnit.Framework;
+    using VRTK.Core.Tracking.Follow.Modifier;
+
+    public class ObjectFollowTest
+    {
+        private GameObject containingObject;
+        private ObjectFollow subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<ObjectFollow>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            subject = null;
+            containingObject = null;
+        }
+
+        [Test]
+        public void ProcessFirstActiveTargetAllActive()
+        {
+            GameObject source = new GameObject("source");
+            GameObject[] targets = new GameObject[]
+            {
+                new GameObject("target1"),
+                new GameObject("target2"),
+                new GameObject("target3")
+            };
+
+            subject.sourceComponent = source.transform;
+            subject.targetComponents = new Component[]
+            {
+                targets[0].transform, targets[1].transform, targets[2].transform
+            };
+
+            FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
+            followModifierMock.processFirstAndActiveOnly = true;
+
+            subject.follow = Data.Enum.TransformProperties.Position;
+            subject.followModifier = followModifierMock;
+
+            subject.Process();
+
+            Assert.AreEqual(Vector3.one, targets[0].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[1].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[2].transform.position);
+        }
+
+        [Test]
+        public void ProcessFirstActiveTargetOnlyLastActive()
+        {
+            GameObject source = new GameObject("source");
+            GameObject[] targets = new GameObject[]
+            {
+                new GameObject("target1"),
+                new GameObject("target2"),
+                new GameObject("target3")
+            };
+
+            subject.sourceComponent = source.transform;
+            subject.targetComponents = new Component[]
+            {
+                targets[0].transform, targets[1].transform, targets[2].transform
+            };
+
+            FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
+            followModifierMock.processFirstAndActiveOnly = true;
+
+            subject.follow = Data.Enum.TransformProperties.Position;
+            subject.followModifier = followModifierMock;
+
+            targets[0].SetActive(false);
+            targets[1].SetActive(false);
+
+            subject.Process();
+
+            Assert.AreEqual(Vector3.zero, targets[0].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[1].transform.position);
+            Assert.AreEqual(Vector3.one, targets[2].transform.position);
+        }
+
+        [Test]
+        public void ProcessAllTargets()
+        {
+            GameObject source = new GameObject("source");
+            GameObject[] targets = new GameObject[]
+            {
+                new GameObject("target1"),
+                new GameObject("target2"),
+                new GameObject("target3")
+            };
+
+            subject.sourceComponent = source.transform;
+            subject.targetComponents = new Component[]
+            {
+                targets[0].transform, targets[1].transform, targets[2].transform
+            };
+
+            FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
+            followModifierMock.processFirstAndActiveOnly = false;
+
+            subject.follow = Data.Enum.TransformProperties.Position;
+            subject.followModifier = followModifierMock;
+
+            subject.Process();
+
+            Assert.AreEqual(Vector3.one, targets[0].transform.position);
+            Assert.AreEqual(Vector3.one, targets[1].transform.position);
+            Assert.AreEqual(Vector3.one, targets[2].transform.position);
+        }
+
+        [Test]
+        public void ProcessPositionOnly()
+        {
+            GameObject source = new GameObject("source");
+            GameObject[] targets = new GameObject[]
+            {
+                new GameObject("target1"),
+                new GameObject("target2"),
+                new GameObject("target3")
+            };
+
+            subject.sourceComponent = source.transform;
+            subject.targetComponents = new Component[]
+            {
+                targets[0].transform, targets[1].transform, targets[2].transform
+            };
+
+            FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
+            followModifierMock.processFirstAndActiveOnly = false;
+
+            subject.follow = Data.Enum.TransformProperties.Position;
+            subject.followModifier = followModifierMock;
+
+            subject.Process();
+
+            Assert.AreEqual(Vector3.one, targets[0].transform.position);
+            Assert.AreEqual(Vector3.one, targets[1].transform.position);
+            Assert.AreEqual(Vector3.one, targets[2].transform.position);
+
+            Assert.AreEqual(Quaternion.identity, targets[0].transform.rotation);
+            Assert.AreEqual(Quaternion.identity, targets[1].transform.rotation);
+            Assert.AreEqual(Quaternion.identity, targets[2].transform.rotation);
+
+            Assert.AreEqual(Vector3.one, targets[0].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[1].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[2].transform.localScale);
+        }
+
+        [Test]
+        public void ProcessRotationOnly()
+        {
+            GameObject source = new GameObject("source");
+            GameObject[] targets = new GameObject[]
+            {
+                new GameObject("target1"),
+                new GameObject("target2"),
+                new GameObject("target3")
+            };
+
+            subject.sourceComponent = source.transform;
+            subject.targetComponents = new Component[]
+            {
+                targets[0].transform, targets[1].transform, targets[2].transform
+            };
+
+            FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
+            followModifierMock.processFirstAndActiveOnly = false;
+
+            subject.follow = Data.Enum.TransformProperties.Rotation;
+            subject.followModifier = followModifierMock;
+
+            subject.Process();
+
+            Quaternion expectedRotation = new Quaternion(1f, 0f, 0f, 0f);
+
+            Assert.AreEqual(Vector3.zero, targets[0].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[1].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[2].transform.position);
+
+            Assert.AreEqual(expectedRotation, targets[0].transform.rotation);
+            Assert.AreEqual(expectedRotation, targets[1].transform.rotation);
+            Assert.AreEqual(expectedRotation, targets[2].transform.rotation);
+
+            Assert.AreEqual(Vector3.one, targets[0].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[1].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[2].transform.localScale);
+        }
+
+        [Test]
+        public void ProcessScaleOnly()
+        {
+            GameObject source = new GameObject("source");
+            GameObject[] targets = new GameObject[]
+            {
+                new GameObject("target1"),
+                new GameObject("target2"),
+                new GameObject("target3")
+            };
+
+            subject.sourceComponent = source.transform;
+            subject.targetComponents = new Component[]
+            {
+                targets[0].transform, targets[1].transform, targets[2].transform
+            };
+
+            FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
+            followModifierMock.processFirstAndActiveOnly = false;
+
+            subject.follow = Data.Enum.TransformProperties.Scale;
+            subject.followModifier = followModifierMock;
+
+            subject.Process();
+
+            Vector3 expectedScale = new Vector3(2f, 2f, 2f);
+
+            Assert.AreEqual(Vector3.zero, targets[0].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[1].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[2].transform.position);
+
+            Assert.AreEqual(Quaternion.identity, targets[0].transform.rotation);
+            Assert.AreEqual(Quaternion.identity, targets[1].transform.rotation);
+            Assert.AreEqual(Quaternion.identity, targets[2].transform.rotation);
+
+            Assert.AreEqual(expectedScale, targets[0].transform.localScale);
+            Assert.AreEqual(expectedScale, targets[1].transform.localScale);
+            Assert.AreEqual(expectedScale, targets[2].transform.localScale);
+        }
+
+        [Test]
+        public void ProcessPositionAndRotationOnly()
+        {
+            GameObject source = new GameObject("source");
+            GameObject[] targets = new GameObject[]
+            {
+                new GameObject("target1"),
+                new GameObject("target2"),
+                new GameObject("target3")
+            };
+
+            subject.sourceComponent = source.transform;
+            subject.targetComponents = new Component[]
+            {
+                targets[0].transform, targets[1].transform, targets[2].transform
+            };
+
+            FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
+            followModifierMock.processFirstAndActiveOnly = false;
+
+            subject.follow = Data.Enum.TransformProperties.Position | Data.Enum.TransformProperties.Rotation;
+            subject.followModifier = followModifierMock;
+
+            subject.Process();
+
+            Quaternion expectedRotation = new Quaternion(1f, 0f, 0f, 0f);
+
+            Assert.AreEqual(Vector3.one, targets[0].transform.position);
+            Assert.AreEqual(Vector3.one, targets[1].transform.position);
+            Assert.AreEqual(Vector3.one, targets[2].transform.position);
+
+            Assert.AreEqual(expectedRotation, targets[0].transform.rotation);
+            Assert.AreEqual(expectedRotation, targets[1].transform.rotation);
+            Assert.AreEqual(expectedRotation, targets[2].transform.rotation);
+
+            Assert.AreEqual(Vector3.one, targets[0].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[1].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[2].transform.localScale);
+        }
+    }
+
+    public class FollowModifierMock : FollowModifier
+    {
+        public bool processFirstAndActiveOnly;
+
+        public override bool ProcessFirstAndActiveOnly()
+        {
+            return processFirstAndActiveOnly;
+        }
+
+        public override void UpdatePosition(Transform source, Transform target)
+        {
+            target.position = Vector3.one;
+        }
+
+        public override void UpdateRotation(Transform source, Transform target)
+        {
+            target.rotation = new Quaternion(1f, 0f, 0f, 0f);
+        }
+
+        public override void UpdateScale(Transform source, Transform target)
+        {
+            target.localScale = new Vector3(2f, 2f, 2f);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs.meta
+++ b/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da75e35dfc2e74f4396a4fa460ee1c1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/TransformModifyTest.cs
+++ b/Tests/Editor/Tracking/TransformModifyTest.cs
@@ -1,0 +1,141 @@
+﻿namespace VRTK.Core.Tracking
+{
+    using UnityEngine;
+    using NUnit.Framework;
+    using VRTK.Core.Data.Type;
+
+    public class TransformModifyTest
+    {
+        private GameObject containingObject;
+        private TransformModify subject;
+
+        private GameObject sourceObject;
+        private GameObject offsetObject;
+        private GameObject targetObject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<TransformModify>();
+
+            sourceObject = new GameObject();
+            offsetObject = new GameObject();
+            targetObject = new GameObject();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            subject = null;
+            containingObject = null;
+
+            sourceObject = null;
+            offsetObject = null;
+            targetObject = null;
+        }
+
+        [Test]
+        public void ModifyPositionNoOffsetInstantTransition()
+        {
+            targetObject.transform.position = Vector3.one;
+
+            subject.source = sourceObject.transform;
+            subject.applyTransformations = Data.Enum.TransformProperties.Position;
+
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+            subject.Modify(targetObject.transform);
+            Assert.AreEqual(Vector3.one, sourceObject.transform.position);
+        }
+
+        [Test]
+        public void ModifyRotationNoOffsetInstantTransition()
+        {
+            Quaternion targetRotation = new Quaternion(1f, 0f, 0f, 0f);
+            targetObject.transform.position = Vector3.one;
+            targetObject.transform.rotation = targetRotation;
+
+            subject.source = sourceObject.transform;
+            subject.applyTransformations = Data.Enum.TransformProperties.Rotation;
+
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+            Assert.AreEqual(Quaternion.identity, sourceObject.transform.rotation);
+            subject.Modify(targetObject.transform);
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+            Assert.AreEqual(targetRotation, sourceObject.transform.rotation);
+        }
+
+        [Test]
+        public void ModifyScaleNoOffsetInstantTransition()
+        {
+            targetObject.transform.position = Vector3.one;
+            targetObject.transform.rotation = new Quaternion(1f, 0f, 0f, 0f);
+            targetObject.transform.localScale = Vector3.one * 2f;
+
+            subject.source = sourceObject.transform;
+            subject.applyTransformations = Data.Enum.TransformProperties.Scale;
+
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+            Assert.AreEqual(Quaternion.identity, sourceObject.transform.rotation);
+            Assert.AreEqual(Vector3.one, sourceObject.transform.localScale);
+            subject.Modify(targetObject.transform);
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+            Assert.AreEqual(Quaternion.identity, sourceObject.transform.rotation);
+            Assert.AreEqual(Vector3.one * 2f, sourceObject.transform.localScale);
+        }
+
+        [Test]
+        public void ModifyTransformWithOffset()
+        {
+            offsetObject.transform.position = Vector3.one;
+            offsetObject.transform.rotation = new Quaternion(0.5f, 0f, 0.5f, 0f);
+
+            targetObject.transform.position = Vector3.one * 2f;
+            targetObject.transform.rotation = new Quaternion(1f, 1f, 0f, 0f);
+            targetObject.transform.localScale = Vector3.one * 3f;
+
+            subject.source = sourceObject.transform;
+            subject.offset = offsetObject.transform;
+            subject.applyTransformations = Data.Enum.TransformProperties.Position | Data.Enum.TransformProperties.Rotation | Data.Enum.TransformProperties.Scale;
+
+            subject.Modify(targetObject.transform);
+            Assert.AreEqual(new Vector3(-1f, -1f, 5f).ToString(), sourceObject.transform.position.ToString());
+            Assert.AreEqual(new Quaternion(0.7f, 0.7f, 0f, 0f).ToString(), sourceObject.transform.rotation.ToString());
+            Assert.AreEqual(Vector3.one * 3f, sourceObject.transform.localScale);
+        }
+
+        [Test]
+        public void ModifyTransformWithXOffsetOnly()
+        {
+            offsetObject.transform.position = Vector3.one;
+            offsetObject.transform.rotation = new Quaternion(0.5f, 0f, 0.5f, 0f);
+
+            targetObject.transform.position = Vector3.one * 2f;
+            targetObject.transform.rotation = new Quaternion(1f, 1f, 0f, 0f);
+            targetObject.transform.localScale = Vector3.one * 3f;
+
+            subject.source = sourceObject.transform;
+            subject.offset = offsetObject.transform;
+            subject.applyOffsetOnAxis = new Vector3State(true, false, false);
+            subject.applyTransformations = Data.Enum.TransformProperties.Position | Data.Enum.TransformProperties.Rotation | Data.Enum.TransformProperties.Scale;
+
+            subject.Modify(targetObject.transform);
+            Assert.AreEqual(new Vector3(2f, -1f, 2f).ToString(), sourceObject.transform.position.ToString());
+            Assert.AreEqual(new Quaternion(0.7f, 0.7f, 0f, 0f).ToString(), sourceObject.transform.rotation.ToString());
+            Assert.AreEqual(Vector3.one * 3f, sourceObject.transform.localScale);
+        }
+
+        [Test]
+        public void ModifyTransformNoSource()
+        {
+            targetObject.transform.position = Vector3.one * 2f;
+            targetObject.transform.rotation = new Quaternion(1f, 1f, 0f, 0f);
+            targetObject.transform.localScale = Vector3.one * 3f;
+
+            subject.Modify(targetObject.transform);
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+            Assert.AreEqual(Quaternion.identity, sourceObject.transform.rotation);
+            Assert.AreEqual(Vector3.one, sourceObject.transform.localScale);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/TransformModifyTest.cs.meta
+++ b/Tests/Editor/Tracking/TransformModifyTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: caad66132d3a2d44a905694af2f7ad9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Object Follow script enables the ability to set a source
component to be affected by a collection of target components based
on the injected modifier. The modifier included in this commit is
the TransformSourceFollowActiveTarget which will make the source
follow the first active target found.

The following is done in a generic Moment Processor that removes
the need to pepper scripts with their own Unity game loop methods
such as Update, FixedUpdate, etc.

The Moment Processor allows defined moments to be processed at a
specified point in the Unity game loop, ensuring a single loop
is dealt with and additional controls can be applied such as only
processing the moments if the Component is active in the scene.