### PR TITLE
feat(Visual): add camera color overlay - fixes #5

### DIFF
--- a/Resources.meta
+++ b/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e625d9d8f9739543baf251e344bdd47
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/Materials.meta
+++ b/Resources/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31f741e4db119574bbfd66fcd5d8f6e0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/Materials/CameraColorOverlay.mat
+++ b/Resources/Materials/CameraColorOverlay.mat
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: CameraColorOverlay
+  m_Shader: {fileID: 4800000, guid: c6488aa155d56e042b5ff808b89c7dda, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 0, b: 0, a: 0.0050360886}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Resources/Materials/CameraColorOverlay.mat.meta
+++ b/Resources/Materials/CameraColorOverlay.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2d9434fe91f6fb447ade6321f272acd7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/Shaders.meta
+++ b/Resources/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3439bb360e94abe4db187453f2fe686f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Resources/Shaders/Unlit_TransparentColor.shader
+++ b/Resources/Shaders/Unlit_TransparentColor.shader
@@ -1,0 +1,29 @@
+﻿Shader "Unlit/TransparentColor"
+{
+	Properties
+	{
+		_Color("Color Tint", Color) = (1,1,1,1)
+		_MainTex("Base (RGB) Alpha (A)", 2D) = "white"
+	}
+
+	Category
+	{
+		Lighting Off
+		ZWrite On
+		Cull back
+		Blend SrcAlpha OneMinusSrcAlpha
+		Tags{ Queue = Transparent }
+
+		SubShader
+		{
+			Pass
+			{
+			SetTexture[_MainTex]
+				{
+				ConstantColor[_Color]
+				Combine Texture * constant
+				}
+			}
+		}
+	}
+}

--- a/Resources/Shaders/Unlit_TransparentColor.shader.meta
+++ b/Resources/Shaders/Unlit_TransparentColor.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c6488aa155d56e042b5ff808b89c7dda
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Visual.meta
+++ b/Scripts/Visual.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ba760ccc928004a4a98feba9d6342c02
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Visual/CameraColorOverlay.cs
+++ b/Scripts/Visual/CameraColorOverlay.cs
@@ -1,0 +1,190 @@
+﻿namespace VRTK.Core.Visual
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The CameraColorOverlay applies a color over the valid cameras and can be used to fade the screen view.
+    /// </summary>
+    public class CameraColorOverlay : MonoBehaviour
+    {
+        [Tooltip("An array of cameras which to apply the color overlay to.")]
+        public List<Camera> validCameras = new List<Camera>();
+        [Tooltip("The color of the overlay.")]
+        public Color overlayColor = Color.black;
+        [Tooltip("The material to use for the overlay.")]
+        public Material overlayMaterial;
+        [Tooltip("The duration of time to apply the overlay color.")]
+        public float addDuration = 0f;
+        [Tooltip("The duration of time to remove the overlay color.")]
+        public float removeDuration = 1f;
+        [Tooltip("The duration of time to wait once the overlay color is applied before it is removed.")]
+        public float appliedDuration = 0f;
+
+        /// <summary>
+        /// The CameraColorOverlayUnityEvent emits an event with the current color being overlaid on the valid cameras along with the sender object.
+        /// </summary>
+        [Serializable]
+        public class CameraColorOverlayUnityEvent : UnityEvent<Color, object>
+        {
+        };
+
+        /// <summary>
+        /// The ColorOverlayAdded event is emitted when the `AddColorOverlay` method is called.
+        /// </summary>
+        public CameraColorOverlayUnityEvent ColorOverlayAdded;
+        /// <summary>
+        /// The ColorOverlayRemoved event is emitted when the `RemoveColorOverlay` method is called.
+        /// </summary>
+        public CameraColorOverlayUnityEvent ColorOverlayRemoved;
+        /// <summary>
+        /// The ColorOverlayChanged event is emitted during the color overlay cycle.
+        /// </summary>
+        public CameraColorOverlayUnityEvent ColorOverlayChanged;
+
+        protected Color targetColor = new Color(0f, 0f, 0f, 0f);
+        protected Color currentColor = new Color(0f, 0f, 0f, 0f);
+        protected Color deltaColor = new Color(0f, 0f, 0f, 0f);
+        protected Coroutine blinkRoutine;
+
+        /// <summary>
+        /// The AddColorOverlay method applies the `overlayColor` to the `validCameras` over the given `addDuration`.
+        /// </summary>
+        public virtual void AddColorOverlay()
+        {
+            CancelBlinkRoutine();
+            AddColorOverlay(overlayColor, addDuration);
+            OnColorOverlayAdded(overlayColor);
+        }
+
+        /// <summary>
+        /// The RemoveColorOverlay method removes the `overlayColor` from the `validCameras` over the given `removeDuration`.
+        /// </summary>
+        public virtual void RemoveColorOverlay()
+        {
+            AddColorOverlay(Color.clear, removeDuration);
+            OnColorOverlayRemoved(Color.clear);
+        }
+
+        /// <summary>
+        /// The Blink method adds the `overlayColor` to the `validCameras` over the given `addDuration` then waits for the given `appliedDuration` then removes the `overlayColor` over the given `removeDuration`.
+        /// </summary>
+        public virtual void Blink()
+        {
+            AddColorOverlay(overlayColor, addDuration);
+            blinkRoutine = StartCoroutine(ResetBlink(addDuration + appliedDuration));
+        }
+
+        protected virtual void OnEnable()
+        {
+            Camera.onPostRender += PostRender;
+        }
+
+        protected virtual void OnDisable()
+        {
+            CancelBlinkRoutine();
+            Camera.onPostRender -= PostRender;
+        }
+
+        protected virtual void OnColorOverlayAdded(Color color)
+        {
+            ColorOverlayAdded?.Invoke(color, this);
+        }
+
+        protected virtual void OnColorOverlayRemoved(Color color)
+        {
+            ColorOverlayRemoved?.Invoke(color, this);
+        }
+
+        protected virtual void OnColorOverlayChanged(Color color)
+        {
+            ColorOverlayChanged?.Invoke(color, this);
+        }
+
+        /// <summary>
+        /// The AddOverlayColor method applies the given color to the `validCameras` over the given duration.
+        /// </summary>
+        /// <param name="newColor">Color to apply to the overlay.</param>
+        /// <param name="duration">The duration over which the color is applied.</param>
+        protected virtual void AddColorOverlay(Color newColor, float duration)
+        {
+            targetColor = newColor;
+            if (duration > 0.0f)
+            {
+                deltaColor = (targetColor - currentColor) / duration;
+            }
+            else
+            {
+                currentColor = newColor;
+            }
+        }
+
+        /// <summary>
+        /// The ResetBlink method waits for the given wait duration and then removes the color overlay over the remove duration.
+        /// </summary>
+        /// <param name="givenWaitDuration">The duration in which to wait before removing the color overlay.</param>
+        /// <returns>An Enumerator to manage the running of the Coroutine.</returns>
+        protected virtual IEnumerator ResetBlink(float givenWaitDuration)
+        {
+            yield return new WaitForSeconds(givenWaitDuration);
+            RemoveColorOverlay();
+        }
+
+        /// <summary>
+        /// The CancelBlinkRoutine cancels any existing running `ResetBlink` Coroutine.
+        /// </summary>
+        protected virtual void CancelBlinkRoutine()
+        {
+            if (blinkRoutine != null)
+            {
+                StopCoroutine(blinkRoutine);
+            }
+        }
+
+        /// <summary>
+        /// The PostRender event on the camera that will apply the color overlay.
+        /// </summary>
+        /// <param name="cam">The camera to apply onto.</param>
+        protected virtual void PostRender(Camera cam)
+        {
+            if (!validCameras.Contains(cam))
+            {
+                return;
+            }
+
+            if (currentColor != targetColor)
+            {
+                if (Mathf.Abs(currentColor.a - targetColor.a) < Mathf.Abs(deltaColor.a) * Time.deltaTime)
+                {
+                    currentColor = targetColor;
+                    deltaColor = new Color(0, 0, 0, 0);
+                }
+                else
+                {
+                    currentColor += deltaColor * Time.deltaTime;
+                }
+                OnColorOverlayChanged(currentColor);
+            }
+
+            if (currentColor.a > 0f && overlayMaterial != null)
+            {
+                currentColor.a = (targetColor.a > currentColor.a && currentColor.a > 0.98f ? 1f : currentColor.a);
+                overlayMaterial.color = currentColor;
+                overlayMaterial.SetPass(0);
+                GL.PushMatrix();
+                GL.LoadOrtho();
+                GL.Color(overlayMaterial.color);
+                GL.Begin(GL.QUADS);
+                GL.Vertex3(0f, 0f, 0.9999f);
+                GL.Vertex3(0f, 1f, 0.9999f);
+                GL.Vertex3(1f, 1f, 0.9999f);
+                GL.Vertex3(1f, 0f, 0.9999f);
+                GL.End();
+                GL.PopMatrix();
+            }
+        }
+    }
+}

--- a/Scripts/Visual/CameraColorOverlay.cs.meta
+++ b/Scripts/Visual/CameraColorOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0b7e5e5f39690a43a2fd345ee851b08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Camera Color Overlay script can be used to fade the color on a
selection of cameras to a new color, which can be useful for fading
the viewpoint or emulating a blink for such things as teleporting.