### PR TITLE
fix(events): ensure all UnityEvents are instantiated to prevent nulls

### DIFF
--- a/Scripts/Tracking/Follow/ObjectFollow.cs
+++ b/Scripts/Tracking/Follow/ObjectFollow.cs
@@ -35,43 +35,43 @@
         /// <summary>
         /// The BeforeProcessed event is emitted before any processing.
         /// </summary>
-        public ObjectFollowUnityEvent BeforeProcessed;
+        public ObjectFollowUnityEvent BeforeProcessed = new ObjectFollowUnityEvent();
         /// <summary>
         /// The AfterProcessed event is emitted after all processing is complete.
         /// </summary>
-        public ObjectFollowUnityEvent AfterProcessed;
+        public ObjectFollowUnityEvent AfterProcessed = new ObjectFollowUnityEvent();
         /// <summary>
         /// The BeforeTransformUpdated event is emitted before the Transform is updated.
         /// </summary>
-        public ObjectFollowUnityEvent BeforeTransformUpdated;
+        public ObjectFollowUnityEvent BeforeTransformUpdated = new ObjectFollowUnityEvent();
         /// <summary>
         /// The AfterTransformUpdated event is emitted after the Transform is updated.
         /// </summary>
-        public ObjectFollowUnityEvent AfterTransformUpdated;
+        public ObjectFollowUnityEvent AfterTransformUpdated = new ObjectFollowUnityEvent();
         /// <summary>
         /// The BeforePositionUpdated event is emitted before the Transform's position is updated.
         /// </summary>
-        public ObjectFollowUnityEvent BeforePositionUpdated;
+        public ObjectFollowUnityEvent BeforePositionUpdated = new ObjectFollowUnityEvent();
         /// <summary>
         /// The AfterPositionUpdated event is emitted after the Transform's position is updated.
         /// </summary>
-        public ObjectFollowUnityEvent AfterPositionUpdated;
+        public ObjectFollowUnityEvent AfterPositionUpdated = new ObjectFollowUnityEvent();
         /// <summary>
         /// The BeforeRotationUpdated event is emitted before the Transform's rotation is updated.
         /// </summary>
-        public ObjectFollowUnityEvent BeforeRotationUpdated;
+        public ObjectFollowUnityEvent BeforeRotationUpdated = new ObjectFollowUnityEvent();
         /// <summary>
         /// The AfterRotationUpdated event is emitted after the Transform's rotation is updated.
         /// </summary>
-        public ObjectFollowUnityEvent AfterRotationUpdated;
+        public ObjectFollowUnityEvent AfterRotationUpdated = new ObjectFollowUnityEvent();
         /// <summary>
         /// The BeforeScaleUpdated event is emitted before the Transform's scale is updated.
         /// </summary>
-        public ObjectFollowUnityEvent BeforeScaleUpdated;
+        public ObjectFollowUnityEvent BeforeScaleUpdated = new ObjectFollowUnityEvent();
         /// <summary>
         /// The AfterScaleUpdated event is emitted after the Transform's scale is updated.
         /// </summary>
-        public ObjectFollowUnityEvent AfterScaleUpdated;
+        public ObjectFollowUnityEvent AfterScaleUpdated = new ObjectFollowUnityEvent();
 
         /// <summary>
         /// The Process method executes the relevant process on the given FollowModifier.

--- a/Scripts/Tracking/TransformModify.cs
+++ b/Scripts/Tracking/TransformModify.cs
@@ -36,11 +36,11 @@
         /// <summary>
         /// The BeforeTransformUpdated event is emitted before the transformation process occurs.
         /// </summary>
-        public TransformModifyUnityEvent BeforeTransformUpdated;
+        public TransformModifyUnityEvent BeforeTransformUpdated = new TransformModifyUnityEvent();
         /// <summary>
         /// The AfterTransformUpdated event is emitted after the transformation process has occured.
         /// </summary>
-        public TransformModifyUnityEvent AfterTransformUpdated;
+        public TransformModifyUnityEvent AfterTransformUpdated = new TransformModifyUnityEvent();
 
         protected Vector3 finalPosition;
         protected Quaternion finalRotation;

--- a/Scripts/Visual/CameraColorOverlay.cs
+++ b/Scripts/Visual/CameraColorOverlay.cs
@@ -35,15 +35,15 @@
         /// <summary>
         /// The ColorOverlayAdded event is emitted when the `AddColorOverlay` method is called.
         /// </summary>
-        public CameraColorOverlayUnityEvent ColorOverlayAdded;
+        public CameraColorOverlayUnityEvent ColorOverlayAdded = new CameraColorOverlayUnityEvent();
         /// <summary>
         /// The ColorOverlayRemoved event is emitted when the `RemoveColorOverlay` method is called.
         /// </summary>
-        public CameraColorOverlayUnityEvent ColorOverlayRemoved;
+        public CameraColorOverlayUnityEvent ColorOverlayRemoved = new CameraColorOverlayUnityEvent();
         /// <summary>
         /// The ColorOverlayChanged event is emitted during the color overlay cycle.
         /// </summary>
-        public CameraColorOverlayUnityEvent ColorOverlayChanged;
+        public CameraColorOverlayUnityEvent ColorOverlayChanged = new CameraColorOverlayUnityEvent();
 
         protected Color targetColor = new Color(0f, 0f, 0f, 0f);
         protected Color currentColor = new Color(0f, 0f, 0f, 0f);


### PR DESCRIPTION
If UnityEvents aren't instantiated at the point of creation then they
will throw a null reference exception if they are referenced via code
e.g. if trying to add a listener to an event via code.

They don't do this in the editor because the editor instantiates the
event type when a new persistent event is added.