### PR TITLE
fix(tests): call DestroyImmediate in teardown for created scene objects

### DIFF
--- a/Tests/Editor/Tracking/Follow/Modifier/TransformSourceFollowActiveTargetTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/TransformSourceFollowActiveTargetTest.cs
@@ -18,8 +18,8 @@
         [TearDown]
         public void TearDown()
         {
-            subject = null;
-            containingObject = null;
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
         }
 
         [Test]

--- a/Tests/Editor/Tracking/Follow/Modifier/TransformTargetsFollowSourceTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/TransformTargetsFollowSourceTest.cs
@@ -18,8 +18,8 @@
         [TearDown]
         public void TearDown()
         {
-            subject = null;
-            containingObject = null;
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
         }
 
         [Test]

--- a/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
@@ -19,8 +19,8 @@
         [TearDown]
         public void TearDown()
         {
-            subject = null;
-            containingObject = null;
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
         }
 
         [Test]

--- a/Tests/Editor/Tracking/TransformModifyTest.cs
+++ b/Tests/Editor/Tracking/TransformModifyTest.cs
@@ -27,12 +27,12 @@
         [TearDown]
         public void TearDown()
         {
-            subject = null;
-            containingObject = null;
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
 
-            sourceObject = null;
-            offsetObject = null;
-            targetObject = null;
+            Object.DestroyImmediate(sourceObject);
+            Object.DestroyImmediate(offsetObject);
+            Object.DestroyImmediate(targetObject);
         }
 
         [Test]

--- a/Tests/Editor/Tracking/Velocity/VelocityEstimatorTest.cs
+++ b/Tests/Editor/Tracking/Velocity/VelocityEstimatorTest.cs
@@ -38,9 +38,8 @@
         [TearDown]
         public void TearDown()
         {
-            subject = null;
-            source = null;
-            containingObject = null;
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
         }
 
         [Test]

--- a/Tests/Editor/Tracking/Velocity/VelocityTrackerProcessorTest.cs
+++ b/Tests/Editor/Tracking/Velocity/VelocityTrackerProcessorTest.cs
@@ -18,8 +18,8 @@
         [TearDown]
         public void TearDown()
         {
-            subject = null;
-            containingObject = null;
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
         }
 
         [Test]


### PR DESCRIPTION
Instead of simply setting created scene objects to `null` in the
teardown on the tests, it's better to call `DestroyImmediate` as this
will ensure the object is destroyed promptly and garbage can be
collected appropriately.