### PR TITLE
feat(Pointers): pointer concept with straight pointer implementation

### DIFF
--- a/Prefabs/Pointers.meta
+++ b/Prefabs/Pointers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c24914d60df83a847ab3ee50d0ba5916
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Shared.meta
+++ b/Prefabs/Pointers/Shared.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1259a1ee1ecba8649bf7e8c8ba96b11e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Shared/Materials.meta
+++ b/Prefabs/Pointers/Shared/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: be650d5bc5870a74f8481f45df804691
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Shared/Materials/PointerDefaultInvalid.mat
+++ b/Prefabs/Pointers/Shared/Materials/PointerDefaultInvalid.mat
@@ -6,8 +6,8 @@ Material:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_Name: CameraColorOverlay
-  m_Shader: {fileID: 4800000, guid: c6488aa155d56e042b5ff808b89c7dda, type: 3}
+  m_Name: PointerDefaultInvalid
+  m_Shader: {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -72,5 +72,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0, g: 0, b: 0, a: 0.0057053864}
+    - _Color: {r: 1, g: 0, b: 0, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Prefabs/Pointers/Shared/Materials/PointerDefaultInvalid.mat.meta
+++ b/Prefabs/Pointers/Shared/Materials/PointerDefaultInvalid.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0085f36199cb6f7458880a2904b15852
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Shared/Materials/PointerDefaultValid.mat
+++ b/Prefabs/Pointers/Shared/Materials/PointerDefaultValid.mat
@@ -6,8 +6,8 @@ Material:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_Name: CameraColorOverlay
-  m_Shader: {fileID: 4800000, guid: c6488aa155d56e042b5ff808b89c7dda, type: 3}
+  m_Name: PointerDefaultValid
+  m_Shader: {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -72,5 +72,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0, g: 0, b: 0, a: 0.0057053864}
+    - _Color: {r: 0, g: 1, b: 0, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Prefabs/Pointers/Shared/Materials/PointerDefaultValid.mat.meta
+++ b/Prefabs/Pointers/Shared/Materials/PointerDefaultValid.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b2b81dec5faebb44ba5dc82f66fb87d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Shared/Scripts.meta
+++ b/Prefabs/Pointers/Shared/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1906603f0ecf2f544988fd8bc9ded5b8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Shared/Scripts/BasePointer.cs
+++ b/Prefabs/Pointers/Shared/Scripts/BasePointer.cs
@@ -1,0 +1,297 @@
+﻿namespace VRTK.Core.Prefabs.Pointer
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using VRTK.Core.Utility;
+    using VRTK.Core.Data.Type;
+
+    /// <summary>
+    /// The PointerData contains information about the current pointer state.
+    /// </summary>
+    public class PointerData : SurfaceData
+    {
+        /// <summary>
+        /// Determines if the pointer is currently in it's activated state.
+        /// </summary>
+        public bool isActive;
+        /// <summary>
+        /// Determines if the pointer is in it's valid state.
+        /// </summary>
+        public bool isValid;
+        /// <summary>
+        /// The duration that the pointer has been hovering over it's current target.
+        /// </summary>
+        public float hoverDuration;
+    }
+
+    /// <summary>
+    /// The BasePointer forms the basis for all pointer types.
+    /// </summary>
+    public abstract class BasePointer : MonoBehaviour
+    {
+        /// <summary>
+        /// The visibility of the pointer element.
+        /// </summary>
+        public enum VisibilityType
+        {
+            /// <summary>
+            /// The element will only be visible when the pointer is in the active state.
+            /// </summary>
+            OnWhenActive,
+            /// <summary>
+            /// The element will always be visible regardless of the pointer state.
+            /// </summary>
+            AlwaysOn,
+            /// <summary>
+            /// The element will never be visible regardless of the pointer state.
+            /// </summary>
+            AlwaysOff
+        }
+
+        [Header("Base Settings")]
+        [Tooltip("An optional ExclusionRule to determine valid and invalid targets based on the set rules.")]
+        public ExclusionRule exclusionRule;
+        [Tooltip("An optional custom PhysicsCast object to affect the Cast of the pointer.")]
+        public PhysicsCast physicsCast;
+
+        /// <summary>
+        /// The PointerUnityEvent emits an event with the PointerData payload and the sender object.
+        /// </summary>
+        [Serializable]
+        public class PointerUnityEvent : UnityEvent<PointerData, object>
+        {
+        };
+
+        [Header("Pointer Events")]
+
+        /// <summary>
+        /// The Activated event is emitted when the pointer becomes active.
+        /// </summary>
+        public PointerUnityEvent Activated = new PointerUnityEvent();
+        /// <summary>
+        /// The Deactivated event is emitted when the pointer becomes inactive.
+        /// </summary>
+        public PointerUnityEvent Deactivated = new PointerUnityEvent();
+        /// <summary>
+        /// The Entered event is emitted when the pointer collides with a new target.
+        /// </summary>
+        public PointerUnityEvent Entered = new PointerUnityEvent();
+        /// <summary>
+        /// The Exited event is emitted when the pointer stops colliding with an existing target.
+        /// </summary>
+        public PointerUnityEvent Exited = new PointerUnityEvent();
+        /// <summary>
+        /// The Hovering event is emitted when the pointer changes its hovering position ove an existing target.
+        /// </summary>
+        public PointerUnityEvent Hovering = new PointerUnityEvent();
+        /// <summary>
+        /// 
+        /// </summary>
+        public PointerUnityEvent Selected = new PointerUnityEvent();
+
+        public abstract bool IsVisible();
+
+        /// <summary>
+        /// Reports the active state of the pointer.
+        /// </summary>
+        public bool Active
+        {
+            get;
+            protected set;
+        }
+
+        /// <summary>
+        /// Reports the valid state of the pointer.
+        /// </summary>
+        public bool Valid
+        {
+            get;
+            protected set;
+        }
+
+        /// <summary>
+        /// Reports hover duration of the pointer over the current target.
+        /// </summary>
+        public float HoverDuration
+        {
+            get;
+            protected set;
+        }
+
+        /// <summary>
+        /// Stores the RayCastHit information of the current pointer collision.
+        /// </summary>
+        public RaycastHit CollisionData
+        {
+            get;
+            protected set;
+        }
+
+        /// <summary>
+        /// Stores the Transform information of the cursor state.
+        /// </summary>
+        public Transform CursorData
+        {
+            protected get;
+            set;
+        }
+
+        protected RaycastHit cachedCollision;
+
+        /// <summary>
+        /// The Activate method turns on the pointer.
+        /// </summary>
+        public virtual void Activate()
+        {
+            Active = true;
+            OnActivated(GetPayload(CursorData, CollisionData));
+        }
+
+        /// <summary>
+        /// The Deactivate method turns off the pointer.
+        /// </summary>
+        public virtual void Deactivate()
+        {
+            Active = false;
+            TryEmitExit();
+            OnDeactivated(GetPayload(CursorData, cachedCollision));
+        }
+
+        /// <summary>
+        /// The Select method emits the selected event if the pointer is active and hovering over a valid target.
+        /// </summary>
+        public virtual void Select()
+        {
+            if (Active && Valid)
+            {
+                OnSelected(GetPayload(CursorData, CollisionData));
+            }
+        }
+
+        /// <summary>
+        /// The IsHovering method returns whether the pointer is currently hovering over a target.
+        /// </summary>
+        /// <returns>Returns `true` if the pointer is currently hovering over a target.</returns>
+        public virtual bool IsHovering()
+        {
+            return (HoverDuration > 0f);
+        }
+
+        /// <summary>
+        /// The IsElementVisible method determines if a given VisibilityType parameter should be considered visible.
+        /// </summary>
+        /// <param name="elementType">The VisibilityType to check for.</param>
+        /// <returns>Returns `true` if the VisibilityType given is considered visible.</returns>
+        public virtual bool IsElementVisible(VisibilityType elementType)
+        {
+            if (!enabled)
+            {
+                return false;
+            }
+
+            switch (elementType)
+            {
+                case VisibilityType.AlwaysOn:
+                    return true;
+                case VisibilityType.AlwaysOff:
+                    return false;
+            }
+            return Active;
+        }
+
+        protected virtual void OnActivated(PointerData e)
+        {
+            Activated?.Invoke(e, this);
+        }
+
+        protected virtual void OnDeactivated(PointerData e)
+        {
+            Deactivated?.Invoke(e, this);
+        }
+
+        protected virtual void OnEntered(PointerData e)
+        {
+            Entered?.Invoke(e, this);
+        }
+
+        protected virtual void OnExited(PointerData e)
+        {
+            Exited?.Invoke(e, this);
+        }
+
+        protected virtual void OnHovering(PointerData e)
+        {
+            Hovering?.Invoke(e, this);
+        }
+
+        protected virtual void OnSelected(PointerData e)
+        {
+            Selected?.Invoke(e, this);
+        }
+
+        /// <summary>
+        /// The CheckValidity method checks the valid state of the pointer collision and determines if the pointer is hovering over a valid target.
+        /// </summary>
+        protected virtual void CheckValidity()
+        {
+            if (Valid)
+            {
+                if (cachedCollision.transform == null || CollisionData.transform != cachedCollision.transform)
+                {
+                    TryEmitExit();
+                    OnEntered(GetPayload(CursorData, CollisionData));
+                }
+                cachedCollision = CollisionData;
+                HoverDuration += Time.deltaTime;
+                OnHovering(GetPayload(CursorData, CollisionData));
+            }
+            else if (cachedCollision.transform != null)
+            {
+                TryEmitExit();
+            }
+
+            if (exclusionRule != null && CollisionData.transform != null)
+            {
+                Valid = !ExclusionRule.ShouldExclude(CollisionData.transform.gameObject, exclusionRule);
+            }
+        }
+
+        /// <summary>
+        /// The TryEmitExit method checks to see if the pointer is not currently colliding with a valid target and emits the Exit event.
+        /// </summary>
+        protected virtual void TryEmitExit()
+        {
+            if (cachedCollision.transform != null)
+            {
+                HoverDuration = 0f;
+                OnExited(GetPayload(CursorData, cachedCollision));
+                cachedCollision = new RaycastHit();
+            }
+        }
+
+        /// <summary>
+        /// The GetPayload method builds a valid Pointer Payload to use in the events.
+        /// </summary>
+        /// <param name="givenCursorData">A Transform containing information about the pointer cursor Transform.</param>
+        /// <param name="givenCollisionData">A RaycastHit containing information about the current pointer collision target.</param>
+        /// <returns>A PointerPayload of the pointer's current state.</returns>
+        protected virtual PointerData GetPayload(Transform givenCursorData, RaycastHit givenCollisionData)
+        {
+            PointerData e = new PointerData
+            {
+                transform = transform,
+                positionOverride = (givenCursorData != null ? (Vector3?)givenCursorData.position : null),
+                rotationOverride = (givenCursorData != null ? (Quaternion?)givenCursorData.localRotation : null),
+                localScaleOverride = (givenCursorData != null ? (Vector3?)givenCursorData.localScale : null),
+                origin = transform.position,
+                direction = transform.forward,
+                CollisionData = givenCollisionData,
+                isActive = Active,
+                isValid = Valid,
+                hoverDuration = HoverDuration
+            };
+            return e;
+        }
+    }
+}

--- a/Prefabs/Pointers/Shared/Scripts/BasePointer.cs.meta
+++ b/Prefabs/Pointers/Shared/Scripts/BasePointer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2cb367b7e2084b744987e63f0807f226
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Straight.meta
+++ b/Prefabs/Pointers/Straight.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c9432d72ece20904ba9b9a90e5888852
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Straight/Scripts.meta
+++ b/Prefabs/Pointers/Straight/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ee5435f76106fd241a65ffa958a28218
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Straight/Scripts/StraightPointer.cs
+++ b/Prefabs/Pointers/Straight/Scripts/StraightPointer.cs
@@ -1,0 +1,176 @@
+﻿namespace VRTK.Core.Prefabs.Pointer
+{
+    using UnityEngine;
+    using VRTK.Core.Utility;
+
+    /// <summary>
+    /// The StraightPointer is a pointer implementation that casts a direct line from the point of origin until it collides with a valid target or reaches it's maximum length.
+    /// </summary>
+    public class StraightPointer : BasePointer
+    {
+        [Header("Pointer Settings")]
+
+        [Tooltip("The maximum length to cast the pointer.")]
+        public float maximumLength = 100f;
+        [Tooltip("The GameObject to represent the pointer's tracer when it is colliding with a valid object.")]
+        public GameObject validTracer;
+        [Tooltip("The GameObject to represent the pointer's cursor when it is colliding with a valid object.")]
+        public GameObject validCursor;
+        [Tooltip("The GameObject to represent the pointer's tracer when it is colliding with an invalid object or not colliding at all.")]
+        public GameObject invalidTracer;
+        [Tooltip("The GameObject to represent the pointer's cursor when it is colliding with an invalid object or not colliding at all.")]
+        public GameObject invalidCursor;
+        [Tooltip("Determines when the pointer tracer GameObject should be seen.")]
+        public VisibilityType tracerVisibility = VisibilityType.OnWhenActive;
+        [Tooltip("Determines when the pointer cursor GameObject should be seen.")]
+        public VisibilityType cursorVisibility = VisibilityType.OnWhenActive;
+        [Tooltip("Determines if the pointer should be automatically activated when the script is enabled.")]
+        public bool activateOnEnable;
+
+        /// <summary>
+        /// The IsVisible method determines if the pointer is currently visible regardless of active state.
+        /// </summary>
+        /// <returns>Returns `true` if the pointer is currently visible.</returns>
+        public override bool IsVisible()
+        {
+            if (!enabled)
+            {
+                return false;
+            }
+
+            if (tracerVisibility == VisibilityType.AlwaysOn || cursorVisibility == VisibilityType.AlwaysOn)
+            {
+                return true;
+            }
+
+            if (tracerVisibility == VisibilityType.AlwaysOff && cursorVisibility == VisibilityType.AlwaysOff)
+            {
+                return false;
+            }
+
+            return Active;
+        }
+
+        /// <summary>
+        /// The Deactivate method turns off the pointer.
+        /// </summary>
+        public override void Deactivate()
+        {
+            base.Deactivate();
+            SetElementState();
+        }
+
+        protected virtual void OnEnable()
+        {
+            Active = activateOnEnable;
+            if (Active)
+            {
+                Activate();
+            }
+            SetElementState();
+        }
+
+        protected virtual void OnDisable()
+        {
+            SetElementState();
+        }
+
+        protected virtual void Update()
+        {
+            if (IsVisible())
+            {
+                float tracerLength = CalculateTracerLength();
+                FormatElements(tracerLength);
+                CheckValidity();
+            }
+            SetElementState();
+            CursorData = (validCursor.transform != null ? validCursor.transform : null);
+        }
+
+        /// <summary>
+        /// The SetElementState method determines the active state of the pointer elements.
+        /// </summary>
+        protected virtual void SetElementState()
+        {
+            SetElementVisible(tracerVisibility, validTracer, invalidTracer);
+            SetElementVisible(cursorVisibility, validCursor, invalidCursor);
+        }
+
+        /// <summary>
+        /// The SetElementVisible method determines the visibility state of the given element.
+        /// </summary>
+        /// <param name="elementType">The VisibilityType parameter of the element to determine visibility for.</param>
+        /// <param name="validElement">The GameObject to set active is the element should be valid.</param>
+        /// <param name="invalidElement">The GameObject to set active is the element should be invalid.</param>
+        protected virtual void SetElementVisible(VisibilityType elementType, GameObject validElement, GameObject invalidElement)
+        {
+            if (IsElementVisible(elementType))
+            {
+                SetElementActive(validElement, Valid);
+                SetElementActive(invalidElement, !Valid);
+            }
+            else
+            {
+                SetElementActive(validElement, false);
+                SetElementActive(invalidElement, false);
+            }
+        }
+
+        /// <summary>
+        /// The SetElementActive method determines the active state of the given element.
+        /// </summary>
+        /// <param name="element">The GameObject of which to set it's active state.</param>
+        /// <param name="state">The state to set on the GameObject.</param>
+        protected virtual void SetElementActive(GameObject element, bool state)
+        {
+            if (element != null)
+            {
+                element.SetActive(state);
+            }
+        }
+
+        /// <summary>
+        /// The CalculateTracerLength method determines the length of the pointer by casting a ray in the forward direction of the Transform.
+        /// </summary>
+        /// <returns>A float representing the distance the length has reached.</returns>
+        protected virtual float CalculateTracerLength()
+        {
+            Ray tracerRaycast = new Ray(transform.position, transform.forward);
+            RaycastHit collision;
+            Valid = PhysicsCast.Raycast(physicsCast, tracerRaycast, out collision, maximumLength, Physics.IgnoreRaycastLayer);
+            CollisionData = collision;
+            return (Valid && CollisionData.distance < maximumLength ? CollisionData.distance : maximumLength);
+        }
+
+        /// <summary>
+        /// The FormatElements method formats the pointer's tracer and cursor shape and position based on the desired length.
+        /// </summary>
+        /// <param name="tracerLength">The length of the pointer to format the relevant elements to.</param>
+        protected virtual void FormatElements(float tracerLength)
+        {
+            SetElementsPosition(validTracer, validCursor, tracerLength);
+            SetElementsPosition(invalidTracer, invalidCursor, tracerLength);
+        }
+
+        /// <summary>
+        /// The SetElementsPosition formats the relevant elements of the pointer in local space.
+        /// </summary>
+        /// <param name="tracer">The GameObject representing the pointer's tracer.</param>
+        /// <param name="cursor">The GameObject representing the pointer's cursor.</param>
+        /// <param name="tracerLength">The length of the pointer tracer.</param>
+        protected virtual void SetElementsPosition(GameObject tracer, GameObject cursor, float tracerLength)
+        {
+            float tracerPosition = tracerLength / 2f;
+            if (tracer != null)
+            {
+                tracer.transform.localScale = new Vector3(tracer.transform.localScale.x, tracer.transform.localScale.y, tracerLength);
+                tracer.transform.localPosition = Vector3.forward * tracerPosition;
+            }
+
+            if (cursor != null)
+            {
+                cursor.transform.localPosition = Vector3.forward * tracerLength;
+            }
+        }
+    }
+}

--- a/Prefabs/Pointers/Straight/Scripts/StraightPointer.cs.meta
+++ b/Prefabs/Pointers/Straight/Scripts/StraightPointer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ddb75ba6ead45404e80f3eb786077170
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Pointers/Straight/StraightPointer.prefab
+++ b/Prefabs/Pointers/Straight/StraightPointer.prefab
@@ -1,0 +1,443 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1364171529147474}
+  m_IsPrefabParent: 1
+--- !u!1 &1090231410205720
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4812912439075832}
+  - component: {fileID: 33922020157499842}
+  - component: {fileID: 23881819983002996}
+  m_Layer: 0
+  m_Name: InvalidTracer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1092691120071124
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4780045773636684}
+  m_Layer: 0
+  m_Name: ValidObjects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1364171529147474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4294201513429860}
+  - component: {fileID: 114284179607794136}
+  m_Layer: 0
+  m_Name: StraightPointer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1678705065220438
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4925001141455402}
+  m_Layer: 0
+  m_Name: InvalidObjects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1753860044894466
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4814935187132282}
+  - component: {fileID: 33536633963422426}
+  - component: {fileID: 23070675765364744}
+  m_Layer: 0
+  m_Name: InvalidCursor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1891565382492296
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4107228353096956}
+  - component: {fileID: 33895316940639426}
+  - component: {fileID: 23881645169444310}
+  m_Layer: 0
+  m_Name: ValidCursor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1957162597281678
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4122752642744664}
+  - component: {fileID: 33750520160137098}
+  - component: {fileID: 23591353561632874}
+  m_Layer: 0
+  m_Name: ValidTracer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4107228353096956
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1891565382492296}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.02, y: 0.02, z: 0.02}
+  m_Children: []
+  m_Father: {fileID: 4780045773636684}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4122752642744664
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1957162597281678}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.0025, y: 0.0025, z: 0.0025}
+  m_Children: []
+  m_Father: {fileID: 4780045773636684}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4294201513429860
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1364171529147474}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4780045773636684}
+  - {fileID: 4925001141455402}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4780045773636684
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1092691120071124}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4122752642744664}
+  - {fileID: 4107228353096956}
+  m_Father: {fileID: 4294201513429860}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4812912439075832
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1090231410205720}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.0025, y: 0.0025, z: 0.0025}
+  m_Children: []
+  m_Father: {fileID: 4925001141455402}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4814935187132282
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1753860044894466}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.02, y: 0.02, z: 0.02}
+  m_Children: []
+  m_Father: {fileID: 4925001141455402}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4925001141455402
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1678705065220438}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4812912439075832}
+  - {fileID: 4814935187132282}
+  m_Father: {fileID: 4294201513429860}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &23070675765364744
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1753860044894466}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 0085f36199cb6f7458880a2904b15852, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!23 &23591353561632874
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1957162597281678}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 5b2b81dec5faebb44ba5dc82f66fb87d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!23 &23881645169444310
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1891565382492296}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 5b2b81dec5faebb44ba5dc82f66fb87d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!23 &23881819983002996
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1090231410205720}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 0085f36199cb6f7458880a2904b15852, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33536633963422426
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1753860044894466}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &33750520160137098
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1957162597281678}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &33895316940639426
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1891565382492296}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!33 &33922020157499842
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1090231410205720}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &114284179607794136
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1364171529147474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ddb75ba6ead45404e80f3eb786077170, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  policyList: {fileID: 0}
+  physicsCast: {fileID: 0}
+  Activated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Prefabs.Pointer.BasePointer+PointerUnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Deactivated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Prefabs.Pointer.BasePointer+PointerUnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Entered:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Prefabs.Pointer.BasePointer+PointerUnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Exited:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Prefabs.Pointer.BasePointer+PointerUnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Hovering:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Prefabs.Pointer.BasePointer+PointerUnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Selected:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Prefabs.Pointer.BasePointer+PointerUnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  maximumLength: 100
+  validTracer: {fileID: 1957162597281678}
+  validCursor: {fileID: 1891565382492296}
+  invalidTracer: {fileID: 1090231410205720}
+  invalidCursor: {fileID: 1753860044894466}
+  tracerVisibility: 0
+  cursorVisibility: 0
+  activateOnEnable: 0

--- a/Prefabs/Pointers/Straight/StraightPointer.prefab.meta
+++ b/Prefabs/Pointers/Straight/StraightPointer.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 58b5a98e395c5614d863555d92d0f45d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Action/SurfaceChangeAction.cs
+++ b/Scripts/Action/SurfaceChangeAction.cs
@@ -1,0 +1,67 @@
+﻿namespace VRTK.Core.Action
+{
+    using UnityEngine;
+    using VRTK.Core.Data.Type;
+    using VRTK.Core.Extension;
+
+    /// <summary>
+    /// The SurfaceChangeAction emits an event when all given actions are in their active state.
+    /// </summary>
+    public class SurfaceChangeAction : BooleanAction
+    {
+        [Tooltip("The distance between the current surface and previous surface to consider a valid change.")]
+        public float changeDistance = 0.5f;
+        [Tooltip("The axes to check for distance differences on.")]
+        public Vector3State checkAxis = new Vector3State(true, true, true);
+
+        /// <summary>
+        /// The Receive method digests SurfaceData and compares the current surface to the previous surface to determine if a change has occured.
+        /// </summary>
+        /// <param name="surfaceData">The SurfaceData to check on.</param>
+        /// <param name="sender">The sender of the action.</param>
+        public virtual void Receive(SurfaceData surfaceData, object sender = null)
+        {
+            if (ValidSurfaceData(surfaceData))
+            {
+                Vector3 generatedOrigin = GetCollisionPoint(surfaceData.PreviousCollisionData);
+                Vector3 generatedTarget = GeneratePoint(surfaceData.Position);
+
+                bool result = !generatedOrigin.Compare(generatedTarget, changeDistance);
+                Receive(result, sender);
+            }
+        }
+
+        /// <summary>
+        /// The ValidSurfaceData method checks to see if the given SurfaceData is valid.
+        /// </summary>
+        /// <param name="surfaceData">The SurfaceData to check on.</param>
+        /// <returns>Returns `true` if the SurfaceData given is valid.</returns>
+        protected virtual bool ValidSurfaceData(SurfaceData surfaceData)
+        {
+            return (surfaceData != null && surfaceData.Valid);
+        }
+
+        /// <summary>
+        /// The GetCollisionPoint method attempts to get the collision point for the given RaycastHit data.
+        /// </summary>
+        /// <param name="collisionData">The RaycastHit data to get the collision point from.</param>
+        /// <returns>Returns a Vector3 of the collision point.</returns>
+        protected virtual Vector3 GetCollisionPoint(RaycastHit collisionData)
+        {
+            return (collisionData.transform != null ? GeneratePoint(collisionData.point) : Vector3.zero);
+        }
+
+        /// <summary>
+        /// The GeneratePoint method creates a Vector3 based on the given point for the valid axes.
+        /// </summary>
+        /// <param name="point">The Point to generate the Vector3 from.</param>
+        /// <returns>A Vector3 of the point only within the valid axes.</returns>
+        protected virtual Vector3 GeneratePoint(Vector3 point)
+        {
+            float resultX = (checkAxis.xState ? point.x : 0f);
+            float resultY = (checkAxis.yState ? point.y : 0f);
+            float resultZ = (checkAxis.zState ? point.z : 0f);
+            return new Vector3(resultX, resultY, resultZ);
+        }
+    }
+}

--- a/Scripts/Action/SurfaceChangeAction.cs.meta
+++ b/Scripts/Action/SurfaceChangeAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1d120f24812793439e55c40dd45fccb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Type/SurfaceData.cs
+++ b/Scripts/Data/Type/SurfaceData.cs
@@ -1,0 +1,62 @@
+﻿namespace VRTK.Core.Data.Type
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The SurfaceData contains information about the located surface.
+    /// </summary>
+    public class SurfaceData : TransformData
+    {
+        /// <summary>
+        /// The origin in which the surface search came from.
+        /// </summary>
+        public Vector3 origin;
+        /// <summary>
+        /// The direction in which the surface search came from.
+        /// </summary>
+        public Vector3 direction;
+        /// <summary>
+        /// RaycastHit data about the current collision.
+        /// </summary>
+        public RaycastHit CollisionData
+        {
+            get
+            {
+                return _collisionData;
+            }
+            set
+            {
+                PreviousCollisionData = _collisionData;
+                _collisionData = value;
+            }
+        }
+        /// <summary>
+        /// RaycastHit data about the previous collision.
+        /// </summary>
+        public RaycastHit PreviousCollisionData
+        {
+            get;
+            protected set;
+        }
+
+        protected RaycastHit _collisionData;
+
+        /// <summary>
+        /// Default Constructor.
+        /// </summary>
+        public SurfaceData()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new SurfaceData with a default origin and direction for the collision search.
+        /// </summary>
+        /// <param name="defaultOrigin"></param>
+        /// <param name="defaultDirection"></param>
+        public SurfaceData(Vector3 defaultOrigin, Vector3 defaultDirection)
+        {
+            origin = defaultOrigin;
+            direction = defaultDirection;
+        }
+    }
+}

--- a/Scripts/Data/Type/SurfaceData.cs.meta
+++ b/Scripts/Data/Type/SurfaceData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d544b518cb4bf848a812345c871119d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Data/Type/TransformData.cs
+++ b/Scripts/Data/Type/TransformData.cs
@@ -1,0 +1,69 @@
+﻿namespace VRTK.Core.Data.Type
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The TrasnformData holds Transform information with the ability to override properties without affecting the scene Transform.
+    /// </summary>
+    public class TransformData
+    {
+        /// <summary>
+        /// A reference to the original transform.
+        /// </summary>
+        public Transform transform;
+        /// <summary>
+        /// Position override of the Transform object.
+        /// </summary>
+        public Vector3? positionOverride = null;
+        /// <summary>
+        /// Rotation override of the Transform object.
+        /// </summary>
+        public Quaternion? rotationOverride = null;
+        /// <summary>
+        /// Scale override of the Transform object.
+        /// </summary>
+        public Vector3? localScaleOverride = null;
+
+        /// <summary>
+        /// The position of the transform or the positionOverride if it is set.
+        /// </summary>
+        public Vector3 Position => positionOverride ?? transform.position;
+
+        /// <summary>
+        /// The rotation of the transform or the rotationOverride if it is set.
+        /// </summary>
+        public Quaternion Rotation => rotationOverride ?? transform.rotation;
+
+        /// <summary>
+        /// The localScale of the transform or the localScaleOverride if it is set.
+        /// </summary>
+        public Vector3 LocalScale => localScaleOverride ?? transform.localScale;
+
+        /// <summary>
+        /// The state of whether the TransformData is valid.
+        /// </summary>
+        public bool Valid
+        {
+            get
+            {
+                return (transform != null);
+            }
+        }
+
+        /// <summary>
+        /// Default Constructor.
+        /// </summary>
+        public TransformData()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new TransformData from an existing Transform.
+        /// </summary>
+        /// <param name="source">The Transform to create the TransformData from.</param>
+        public TransformData(Transform source)
+        {
+            transform = source;
+        }
+    }
+}

--- a/Scripts/Data/Type/TransformData.cs.meta
+++ b/Scripts/Data/Type/TransformData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c6ed4a6da327ad47a488af2de212bb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Extension/Vector3Extensions.cs
+++ b/Scripts/Extension/Vector3Extensions.cs
@@ -1,0 +1,22 @@
+﻿namespace VRTK.Core.Extension
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The Vector3Extensions provide extended methods for the Vector3 Type.
+    /// </summary>
+    public static class Vector3Extensions
+    {
+        /// <summary>
+        /// The Compare method determines if two vectors are equal based on a given distance.
+        /// </summary>
+        /// <param name="a">The Vector3 to compare against.</param>
+        /// <param name="b">The Vector3 to compare with.</param>
+        /// <param name="distance">The distance in which the two Vector3 objects can be within to be considered equal</param>
+        /// <returns>Returns `true` if the two Vector3 values are considered equal.</returns>
+        public static bool Compare(this Vector3 a, Vector3 b, float distance)
+        {
+            return (Vector3.Distance(a, b) <= distance);
+        }
+    }
+}

--- a/Scripts/Extension/Vector3Extensions.cs.meta
+++ b/Scripts/Extension/Vector3Extensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d58c55f5a8510648b54e3a6e1306019
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tracking/SurfaceLocator.cs
+++ b/Scripts/Tracking/SurfaceLocator.cs
@@ -1,0 +1,140 @@
+﻿namespace VRTK.Core.Tracking
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using VRTK.Core.Utility;
+    using VRTK.Core.Data.Type;
+    using VRTK.Core.Process;
+    using VRTK.Core.Extension;
+
+    /// <summary>
+    /// The SurfaceLocator casts a ray in a given direction and looks for the nearest valid surface.
+    /// </summary>
+    public class SurfaceLocator : MonoBehaviour, IProcessable
+    {
+        [Tooltip("The origin of where to begin the cast to locate the nearest surface.")]
+        public Transform searchOrigin;
+        [Tooltip("The direction in which to cast to locate the nearest surface.")]
+        public Vector3 searchDirection;
+        [Tooltip("The distance to move the origin backwards through the `searchDirection` to ensure the origin isn't clipping a surface.")]
+        public float originOffset = -0.01f;
+        [Tooltip("The maximum distance to cast the ray.")]
+        public float maximumDistance = 50f;
+        [Tooltip("An optional ExclusionRule to determine valid and invalid targets based on the set rules.")]
+        public ExclusionRule exclusionRule;
+        [Tooltip("An optional custom PhysicsCast object to affect the Cast of the pointer.")]
+        public PhysicsCast physicsCast;
+
+        protected const float DISTANCE_VARIANCE = 0.0001f;
+
+        /// <summary>
+        /// The SurfaceLocatorUnityEvent emits an event with the SurfaceData payload and the sender object.
+        /// </summary>
+        [Serializable]
+        public class SurfaceLocatorUnityEvent : UnityEvent<SurfaceData, object>
+        {
+        };
+
+        /// <summary>
+        /// The SurfaceLocated event is emitted when a new surface is located.
+        /// </summary>
+        public SurfaceLocatorUnityEvent SurfaceLocated = new SurfaceLocatorUnityEvent();
+
+        /// <summary>
+        /// The SurfaceData about the located surface.
+        /// </summary>
+        public SurfaceData SurfaceData
+        {
+            get;
+            protected set;
+        }
+
+        /// <summary>
+        /// The Process method attempts to locate the nearest available surface upon a MomentProcess.
+        /// </summary>
+        public virtual void Process()
+        {
+            Locate();
+        }
+
+        /// <summary>
+        /// The Locate method attempts to locate the nearest available surface with the specified `searchOrigin` Transform.
+        /// </summary>
+        public virtual void Locate()
+        {
+            Locate(new TransformData(searchOrigin));
+        }
+
+        /// <summary>
+        /// The Locate method attempts to locate the nearest available surface with the given TransformData.
+        /// </summary>
+        /// <param name="givenOrigin">The TransformData object to use as the origin for the surface search.</param>
+        /// <param name="initiator">The object which initiated the method.</param>
+        public virtual void Locate(TransformData givenOrigin, object initiator = null)
+        {
+            if (givenOrigin != null && givenOrigin.Valid && CastRay(givenOrigin.Position, searchDirection) && PositionChanged(DISTANCE_VARIANCE))
+            {
+                OnSurfaceLocated(SurfaceData);
+            }
+        }
+
+        protected virtual void OnSurfaceLocated(SurfaceData e)
+        {
+            SurfaceLocated?.Invoke(e, this);
+        }
+
+        /// <summary>
+        /// The PositionChanged method checks to see if the surface position has changed between frames.
+        /// </summary>
+        /// <param name="checkDistance">The distance to consider a position change.</param>
+        /// <returns>Returns `true` if the surface position has changed or no previous surface data is found.</returns>
+        protected virtual bool PositionChanged(float checkDistance)
+        {
+            return (SurfaceData.PreviousCollisionData.transform == null || !SurfaceData.Position.Compare(SurfaceData.PreviousCollisionData.point, checkDistance));
+        }
+
+        /// <summary>
+        /// The CastRay method casts a ray in the given direction from the given origin to search the nearest surface.
+        /// </summary>
+        /// <param name="givenOrigin">The origin to begin the RayCast from.</param>
+        /// <param name="givenDirection">The direction in which to cast the ray.</param>
+        /// <returns>Returns `true` if a valid surface is located.</returns>
+        protected virtual bool CastRay(Vector3 givenOrigin, Vector3 givenDirection)
+        {
+            givenOrigin = givenOrigin + (givenDirection.normalized * originOffset);
+            if (SurfaceData == null)
+            {
+                SurfaceData = new SurfaceData();
+            }
+            SurfaceData.origin = givenOrigin;
+            SurfaceData.direction = givenDirection;
+            Ray tracerRaycast = new Ray(givenOrigin, givenDirection);
+            RaycastHit collision;
+            bool collided = PhysicsCast.Raycast(physicsCast, tracerRaycast, out collision, maximumDistance, Physics.IgnoreRaycastLayer);
+            SurfaceData.CollisionData = collision;
+
+            if (collided && ValidSurface(SurfaceData.CollisionData))
+            {
+                SurfaceData.transform = SurfaceData.CollisionData.transform;
+                SurfaceData.positionOverride = SurfaceData.CollisionData.point;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The ValidSurface method determines whether the RaycastHit data contains a valid surface.
+        /// </summary>
+        /// <param name="collisionData">The RaycastHit data to check for validity on.</param>
+        /// <returns>Returns `true` if the RaycastHit data contains a valid surface.</returns>
+        protected virtual bool ValidSurface(RaycastHit collisionData)
+        {
+            if (exclusionRule != null && collisionData.transform != null)
+            {
+                return !ExclusionRule.ShouldExclude(collisionData.transform.gameObject, exclusionRule);
+            }
+            return true;
+        }
+    }
+}

--- a/Scripts/Tracking/SurfaceLocator.cs.meta
+++ b/Scripts/Tracking/SurfaceLocator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f7fe420339e958499aa62748577d273
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Utility/ExclusionRule.cs
+++ b/Scripts/Utility/ExclusionRule.cs
@@ -1,0 +1,222 @@
+﻿namespace VRTK.Core.Utility
+{
+    using UnityEngine;
+    using System;
+    using System.Collections.Generic;
+    using VRTK.Core.Data.Attribute;
+
+    /// <summary>
+    /// The ExclusionRule allows to create a list of either tag names, script names or layer names that can be checked against to see if another operation should be excluded or permitted.
+    /// </summary>
+    public class ExclusionRule : MonoBehaviour
+    {
+        /// <summary>
+        /// The operation to apply on the list of identifiers.
+        /// </summary>
+        public enum OperationType
+        {
+            /// <summary>
+            /// Will ignore any GameObjects that contain the CheckType that is included in the identifiers list.
+            /// </summary>
+            Ignore,
+            /// <summary>
+            /// Will only include any GameObjects that contain the CheckType that is included in the identifiers list.
+            /// </summary>
+            Include
+        }
+
+        /// <summary>
+        /// The types of element that can be checked against.
+        /// </summary>
+        [Flags]
+        public enum CheckTypes
+        {
+            /// <summary>
+            /// The tag applied to the GameObject.
+            /// </summary>
+            Tag = 1 << 0,
+            /// <summary>
+            /// A script component added to the GameObject.
+            /// </summary>
+            Script = 1 << 1,
+            /// <summary>
+            /// A layer applied to the GameObject.
+            /// </summary>
+            Layer = 1 << 2
+        }
+
+        [Tooltip("The operation to apply on the list of identifiers.")]
+        public OperationType operation = OperationType.Ignore;
+        [UnityFlag]
+        [Tooltip("The element type on the GameObject to check against.")]
+        public CheckTypes checkType = CheckTypes.Tag;
+        [Tooltip("A list of identifiers to check against the given check type.")]
+        public List<string> identifiers = new List<string>();
+
+        /// <summary>
+        /// The ShouldExclude method is used to determine if a GameObject should be considered excluded due to the set rules.
+        /// </summary>
+        /// <param name="obj">The GameObject to check.</param>
+        /// <param name="rule">The ExclusionRule to use for checking.</param>
+        /// <returns>Returns `true` if the given GameObject should be excluded based on the set rules.</returns>
+        public static bool ShouldExclude(GameObject obj, ExclusionRule rule)
+        {
+            if (rule != null)
+            {
+                return rule.ShouldExclude(obj);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The ShouldExclude method is used to determine if a GameObject should be considered excluded due to the set rules.
+        /// </summary>
+        /// <param name="obj">The GameObject to check.</param>
+        /// <returns>Returns `true` if the given GameObject should be excluded based on the set rules.</returns>
+        public virtual bool ShouldExclude(GameObject obj)
+        {
+            if (operation == OperationType.Ignore)
+            {
+                return TypeCheck(obj, true);
+            }
+            else
+            {
+                return TypeCheck(obj, false);
+            }
+        }
+
+        /// <summary>
+        /// The ScriptCheck method determines if the given GameObject has a script named after one of the identifiers.
+        /// </summary>
+        /// <param name="obj">The GameObject to check.</param>
+        /// <param name="returnState">The current state of the check.</param>
+        /// <returns>Returns `true` if the GameObject does have a script named after one of the identifiers.</returns>
+        protected virtual bool ScriptCheck(GameObject obj, bool returnState)
+        {
+            for (int i = 0; i < identifiers.Count; i++)
+            {
+                if (obj.GetComponent(identifiers[i]))
+                {
+                    return returnState;
+                }
+            }
+            return !returnState;
+        }
+
+        /// <summary>
+        /// The TagCheck method determines if the given GameObject has a tag named after one of the identifiers.
+        /// </summary>
+        /// <param name="obj">The GameObject to check.</param>
+        /// <param name="returnState">The current state of the check.</param>
+        /// <returns>Returns `true` if the GameObject does have a tag named after one of the identifiers.</returns>
+        protected virtual bool TagCheck(GameObject obj, bool returnState)
+        {
+            if (returnState)
+            {
+                return identifiers.Contains(obj.tag);
+            }
+            else
+            {
+                return !identifiers.Contains(obj.tag);
+            }
+        }
+
+        /// <summary>
+        /// The LayerCheck method determines if the given GameObject is on a layer named after one of the identifiers.
+        /// </summary>
+        /// <param name="obj">The GameObject to check.</param>
+        /// <param name="returnState">The current state of the check.</param>
+        /// <returns>Returns `true` if the GameObject is on a layer named after one of the identifiers.</returns>
+        protected virtual bool LayerCheck(GameObject obj, bool returnState)
+        {
+            if (returnState)
+            {
+                return identifiers.Contains(LayerMask.LayerToName(obj.layer));
+            }
+            else
+            {
+                return !identifiers.Contains(LayerMask.LayerToName(obj.layer));
+            }
+        }
+
+        /// <summary>
+        /// The TypeCheck method determines the mechanism for checking the GameObject matches the appropriate identifiers.
+        /// </summary>
+        /// <param name="obj">The GameObject to check.</param>
+        /// <param name="returnState">The current state of the check.</param>
+        /// <returns>Returns `true` if the GameObject matches an appropriate identifier.</returns>
+        protected virtual bool TypeCheck(GameObject obj, bool returnState)
+        {
+            int selection = 0;
+
+            if (checkType.HasFlag(CheckTypes.Tag))
+            {
+                selection += 1;
+            }
+            if (checkType.HasFlag(CheckTypes.Script))
+            {
+                selection += 2;
+            }
+            if (checkType.HasFlag(CheckTypes.Layer))
+            {
+                selection += 4;
+            }
+
+            switch (selection)
+            {
+                case 1:
+                    return TagCheck(obj, returnState);
+                case 2:
+                    return ScriptCheck(obj, returnState);
+                case 3:
+                    if ((returnState && TagCheck(obj, returnState)) || (!returnState && !TagCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && ScriptCheck(obj, returnState)) || (!returnState && !ScriptCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 4:
+                    return LayerCheck(obj, returnState);
+                case 5:
+                    if ((returnState && TagCheck(obj, returnState)) || (!returnState && !TagCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && LayerCheck(obj, returnState)) || (!returnState && !LayerCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 6:
+                    if ((returnState && ScriptCheck(obj, returnState)) || (!returnState && !ScriptCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && LayerCheck(obj, returnState)) || (!returnState && !LayerCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+                case 7:
+                    if ((returnState && TagCheck(obj, returnState)) || (!returnState && !TagCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && ScriptCheck(obj, returnState)) || (!returnState && !ScriptCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && LayerCheck(obj, returnState)) || (!returnState && !LayerCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+            }
+
+            return !returnState;
+        }
+    }
+}

--- a/Scripts/Utility/ExclusionRule.cs.meta
+++ b/Scripts/Utility/ExclusionRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e93473fc500c8f4e98a5858bcb43c83
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Utility/PhysicsCast.cs
+++ b/Scripts/Utility/PhysicsCast.cs
@@ -1,0 +1,201 @@
+﻿namespace VRTK.Core.Utility
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The PhysicsCast allows customising of Unity Physics casting within other scripts by applying settings at edit time.
+    /// </summary>
+    public class PhysicsCast : MonoBehaviour
+    {
+        [Tooltip("The layers to ignore when casting.")]
+        public LayerMask layersToIgnore = Physics.IgnoreRaycastLayer;
+        [Tooltip("Determines whether the cast will interact with trigger colliders.")]
+        public QueryTriggerInteraction triggerInteraction = QueryTriggerInteraction.UseGlobal;
+
+        /// <summary>
+        /// The Raycast method is used to generate a Raycast either from the given PhysicsCast object or a default Physics.Raycast.
+        /// </summary>
+        /// <param name="customCast">The optional object with customised cast parameters.</param>
+        /// <param name="ray">The Ray to cast with.</param>
+        /// <param name="hitData">The Raycast hit data.</param>
+        /// <param name="length">The maximum length of the Raycast.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the Raycast.</param>
+        /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
+        /// <returns>Returns `true` if the Raycast successfully collides with a valid object.</returns>
+        public static bool Raycast(PhysicsCast customCast, Ray ray, out RaycastHit hitData, float length, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
+        {
+            if (customCast != null)
+            {
+                return customCast.CustomRaycast(ray, out hitData, length);
+            }
+            else
+            {
+                return Physics.Raycast(ray, out hitData, length, ~ignoreLayers, affectTriggers);
+            }
+        }
+
+        /// <summary>
+        /// The Linecast method is used to generate a Linecast either from the given PhysicsCast object or a default Physics.Linecast.
+        /// </summary>
+        /// <param name="customCast">The optional object with customised cast parameters.</param>
+        /// <param name="startPosition">The world position to start the Linecast from.</param>
+        /// <param name="endPosition">The world position to end the Linecast at.</param>
+        /// <param name="hitData">The Linecast hit data.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the Linecast.</param>
+        /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
+        /// <returns>Returns `true` if the Linecast successfully collides with a valid object.</returns>
+        public static bool Linecast(PhysicsCast customCast, Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
+        {
+            if (customCast != null)
+            {
+                return customCast.CustomLinecast(startPosition, endPosition, out hitData);
+            }
+            else
+            {
+                return Physics.Linecast(startPosition, endPosition, out hitData, ~ignoreLayers, affectTriggers);
+            }
+        }
+
+        /// <summary>
+        /// The SphereCast method is used to generate a SphereCast either from the given PhysicsCast object or a default Physics.SphereCast.
+        /// </summary>
+        /// <param name="customCast">The optional object with customised cast parameters.</param>
+        /// <param name="origin">The origin point of the sphere to cast.</param>
+        /// <param name="radius">The radius of the sphere.</param>
+        /// <param name="direction">The direction into which to sweep the sphere.</param>
+        /// <param name="hitData">The SphereCast hit data.</param>
+        /// <param name="maxDistance">The max length of the sweep.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the SphereCast.</param>
+        /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
+        /// <returns>Returns `true` if the SphereCast successfully collides with a valid object.</returns>
+        public static bool SphereCast(PhysicsCast customCast, Vector3 origin, float radius, Vector3 direction, out RaycastHit hitData, float maxDistance, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
+        {
+            if (customCast != null)
+            {
+                return customCast.CustomSphereCast(origin, radius, direction, out hitData, maxDistance);
+            }
+            else
+            {
+                return Physics.SphereCast(origin, radius, direction, out hitData, maxDistance, ~ignoreLayers, affectTriggers);
+            }
+        }
+
+        /// <summary>
+        /// The CapsuleCast method is used to generate a CapsuleCast either from the given PhysicsCast object or a default Physics.CapsuleCast.
+        /// </summary>
+        /// <param name="customCast">The optional object with customised cast parameters.</param>
+        /// <param name="point1">The center of the sphere at the start of the capsule.</param>
+        /// <param name="point2">The center of the sphere at the end of the capsule.</param>
+        /// <param name="radius">The radius of the capsule.</param>
+        /// <param name="direction">The direction into which to sweep the capsule.</param>
+        /// <param name="hitData">The CapsuleCast hit data.</param>
+        /// <param name="maxDistance">The max length of the sweep.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the CapsuleCast.</param>
+        /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
+        /// <returns>Returns `true` if the CapsuleCast successfully collides with a valid object.</returns>
+        public static bool CapsuleCast(PhysicsCast customCast, Vector3 point1, Vector3 point2, float radius, Vector3 direction, out RaycastHit hitData, float maxDistance, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
+        {
+            if (customCast != null)
+            {
+                return customCast.CustomCapsuleCast(point1, point2, radius, direction, out hitData, maxDistance);
+            }
+            else
+            {
+                return Physics.CapsuleCast(point1, point2, radius, direction, out hitData, maxDistance, ~ignoreLayers, affectTriggers);
+            }
+        }
+
+        /// <summary>
+        /// The BoxCast method is used to generate a BoxCast either from the given PhysicsCast object or a default Physics.BoxCast.
+        /// </summary>
+        /// <param name="customCast">The optional object with customised cast parameters.</param>
+        /// <param name="center">The center of the box.</param>
+        /// <param name="halfExtents">Half the size of the box in each dimension.</param>
+        /// <param name="direction">The direction in which to cast the box.</param>
+        /// <param name="hitData">The BoxCast hit data.</param>
+        /// <param name="orientation">The rotation of the box.</param>
+        /// <param name="maxDistance">The max length of the cast.</param>
+        /// <param name="ignoreLayers">A layermask of layers to ignore from the BoxCast.</param>
+        /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
+        /// <returns>Returns `true` if the BoxCast successfully collides with a valid object.</returns>
+        public static bool BoxCast(PhysicsCast customCast, Vector3 center, Vector3 halfExtents, Vector3 direction, out RaycastHit hitData, Quaternion orientation, float maxDistance, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
+        {
+            if (customCast != null)
+            {
+                return customCast.CustomBoxCast(center, halfExtents, direction, out hitData, orientation, maxDistance);
+            }
+            else
+            {
+                return Physics.BoxCast(center, halfExtents, direction, out hitData, orientation, maxDistance, ~ignoreLayers, affectTriggers);
+            }
+        }
+
+        /// <summary>
+        /// The CustomRaycast method is used to generate a Raycast based on the options defined in the PhysicsCast object.
+        /// </summary>
+        /// <param name="ray">The Ray to cast with.</param>
+        /// <param name="hitData">The Raycast hit data.</param>
+        /// <param name="length">The maximum length of the Raycast.</param>
+        /// <returns>Returns `true` if the Raycast successfully collides with a valid object.</returns>
+        public virtual bool CustomRaycast(Ray ray, out RaycastHit hitData, float length)
+        {
+            return Physics.Raycast(ray, out hitData, length, ~layersToIgnore, triggerInteraction);
+        }
+
+        /// <summary>
+        /// The CustomLinecast method is used to generate a Linecast based on the options defined in the PhysicsCast object.
+        /// </summary>
+        /// <param name="startPosition">The world position to start the Linecast from.</param>
+        /// <param name="endPosition">The world position to end the Linecast at.</param>
+        /// <param name="hitData">The Linecast hit data.</param>
+        /// <returns>Returns `true` if the Linecast successfully collides with a valid object.</returns>
+        public virtual bool CustomLinecast(Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData)
+        {
+            return Physics.Linecast(startPosition, endPosition, out hitData, ~layersToIgnore, triggerInteraction);
+        }
+
+        /// <summary>
+        /// The CustomSphereCast method is used to generate a SphereCast based on the options defined in the PhysicsCast object.
+        /// </summary>
+        /// <param name="origin">The origin point of the sphere to cast.</param>
+        /// <param name="radius">The radius of the sphere.</param>
+        /// <param name="direction">The direction into which to sweep the sphere.</param>
+        /// <param name="hitData">The SphereCast hit data.</param>
+        /// <param name="maxDistance">The max length of the sweep.</param>
+        /// <returns>Returns `true` if the SphereCast successfully collides with a valid object.</returns>
+        public virtual bool CustomSphereCast(Vector3 origin, float radius, Vector3 direction, out RaycastHit hitData, float maxDistance)
+        {
+            return Physics.SphereCast(origin, radius, direction, out hitData, maxDistance, ~layersToIgnore, triggerInteraction);
+        }
+
+        /// <summary>
+        /// The CustomCapsuleCast method is used to generate a CapsuleCast based on the options defined in the PhysicsCast object.
+        /// </summary>
+        /// <param name="point1">The center of the sphere at the start of the capsule.</param>
+        /// <param name="point2">The center of the sphere at the end of the capsule.</param>
+        /// <param name="radius">The radius of the capsule.</param>
+        /// <param name="direction">The direction into which to sweep the capsule.</param>
+        /// <param name="hitData">The CapsuleCast hit data.</param>
+        /// <param name="maxDistance">The max length of the sweep.</param>
+        /// <returns>Returns `true` if the CapsuleCast successfully collides with a valid object.</returns>
+        public virtual bool CustomCapsuleCast(Vector3 point1, Vector3 point2, float radius, Vector3 direction, out RaycastHit hitData, float maxDistance)
+        {
+            return Physics.CapsuleCast(point1, point2, radius, direction, out hitData, maxDistance, ~layersToIgnore, triggerInteraction);
+        }
+
+        /// <summary>
+        /// The CustomBoxCast method is used to generate a BoxCast based on the options defined in the PhysicsCast object.
+        /// </summary>
+        /// <param name="center">The center of the box.</param>
+        /// <param name="halfExtents">Half the size of the box in each dimension.</param>
+        /// <param name="direction">The direction in which to cast the box.</param>
+        /// <param name="hitData">The BoxCast hit data.</param>
+        /// <param name="orientation">The rotation of the box.</param>
+        /// <param name="maxDistance">The max length of the cast.</param>
+        /// <returns>Returns `true` if the box successfully collides with a valid object.</returns>
+        public virtual bool CustomBoxCast(Vector3 center, Vector3 halfExtents, Vector3 direction, out RaycastHit hitData, Quaternion orientation, float maxDistance)
+        {
+            return Physics.BoxCast(center, halfExtents, direction, out hitData, orientation, maxDistance, ~layersToIgnore, triggerInteraction);
+        }
+    }
+}

--- a/Scripts/Utility/PhysicsCast.cs.meta
+++ b/Scripts/Utility/PhysicsCast.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 406d478cdbf496a4ead48dfdc7df8d0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Visual/CameraColorOverlay.cs
+++ b/Scripts/Visual/CameraColorOverlay.cs
@@ -45,6 +45,7 @@
         /// </summary>
         public CameraColorOverlayUnityEvent ColorOverlayChanged = new CameraColorOverlayUnityEvent();
 
+        protected float targetDuration;
         protected Color targetColor = new Color(0f, 0f, 0f, 0f);
         protected Color currentColor = new Color(0f, 0f, 0f, 0f);
         protected Color deltaColor = new Color(0f, 0f, 0f, 0f);
@@ -55,9 +56,7 @@
         /// </summary>
         public virtual void AddColorOverlay()
         {
-            CancelBlinkRoutine();
             AddColorOverlay(overlayColor, addDuration);
-            OnColorOverlayAdded(overlayColor);
         }
 
         /// <summary>
@@ -111,14 +110,25 @@
         /// <param name="duration">The duration over which the color is applied.</param>
         protected virtual void AddColorOverlay(Color newColor, float duration)
         {
-            targetColor = newColor;
-            if (duration > 0.0f)
+            CancelBlinkRoutine();
+
+            if (newColor != targetColor || duration != targetDuration)
             {
-                deltaColor = (targetColor - currentColor) / duration;
-            }
-            else
-            {
-                currentColor = newColor;
+                targetDuration = duration;
+                targetColor = newColor;
+                if (duration > 0.0f)
+                {
+                    deltaColor = (targetColor - currentColor) / duration;
+                }
+                else
+                {
+                    currentColor = newColor;
+                }
+
+                if (newColor != Color.clear)
+                {
+                    OnColorOverlayAdded(overlayColor);
+                }
             }
         }
 

--- a/Tests/Editor/Action/SurfaceChangeActionTest.cs
+++ b/Tests/Editor/Action/SurfaceChangeActionTest.cs
@@ -1,0 +1,101 @@
+﻿namespace VRTK.Core.Action
+{
+    using UnityEngine;
+    using NUnit.Framework;
+    using VRTK.Core.Utility.Mock;
+    using VRTK.Core.Data.Type;
+
+    public class SurfaceChangeActionTest
+    {
+        private GameObject containingObject;
+        private SurfaceChangeActionMock subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<SurfaceChangeActionMock>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void SurfaceChanged()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.changeDistance = 1f;
+            subject.checkAxis = Vector3State.True;
+
+            SurfaceData surfaceData = new SurfaceData(Vector3.one, Vector3.down);
+
+            //set current surface to zero
+            RaycastHit ray = new RaycastHit
+            {
+                point = Vector3.zero
+            };
+            surfaceData.CollisionData = ray;
+            surfaceData.positionOverride = ray.point;
+            //set surface to one so there is a change between surface positions
+            ray = new RaycastHit
+            {
+                point = Vector3.one
+            };
+            surfaceData.CollisionData = ray;
+            surfaceData.positionOverride = ray.point;
+
+            subject.Receive(surfaceData, null);
+
+            Assert.IsTrue(activatedListenerMock.Received);
+        }
+
+        [Test]
+        public void SurfaceUnchanged()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.changeDistance = 1f;
+            subject.checkAxis = new Vector3State(false, true, false);
+
+            SurfaceData surfaceData = new SurfaceData(Vector3.one, Vector3.down);
+
+            //set current surface to zero
+            RaycastHit ray = new RaycastHit
+            {
+                point = Vector3.zero
+            };
+            surfaceData.CollisionData = ray;
+            surfaceData.positionOverride = ray.point;
+            //set surface to one so there is a change between surface positions
+            ray = new RaycastHit
+            {
+                point = Vector3.one
+            };
+            surfaceData.CollisionData = ray;
+            surfaceData.positionOverride = ray.point;
+
+            subject.Receive(surfaceData, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+        }
+    }
+
+    public class SurfaceChangeActionMock : SurfaceChangeAction
+    {
+        //As The transform in the RaycastHit cannot be set without doing an actual raycast, just ignore that check for the test.
+        protected override bool ValidSurfaceData(SurfaceData surfaceData)
+        {
+            return true;
+        }
+
+        protected override Vector3 GetCollisionPoint(RaycastHit collisionData)
+        {
+            return GeneratePoint(collisionData.point);
+        }
+    }
+}

--- a/Tests/Editor/Action/SurfaceChangeActionTest.cs.meta
+++ b/Tests/Editor/Action/SurfaceChangeActionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 991b5c4ae4ea0e7459d6dbb9c3193a37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Data/Type/SurfaceDataTest.cs
+++ b/Tests/Editor/Data/Type/SurfaceDataTest.cs
@@ -1,0 +1,64 @@
+﻿namespace VRTK.Core.Data.Type
+{
+    using UnityEngine;
+    using NUnit.Framework;
+
+    public class SurfaceDataTest
+    {
+        [Test]
+        public void DefaultConstructor()
+        {
+            SurfaceData surfaceData = new SurfaceData();
+            Assert.AreEqual(Vector3.zero, surfaceData.origin);
+            Assert.AreEqual(Vector3.zero, surfaceData.direction);
+        }
+
+        [Test]
+        public void OriginConstructor()
+        {
+            SurfaceData surfaceData = new SurfaceData(Vector3.one, Vector3.forward);
+            Assert.AreEqual(Vector3.one, surfaceData.origin);
+            Assert.AreEqual(Vector3.forward, surfaceData.direction);
+        }
+
+        [Test]
+        public void CollisionData()
+        {
+            SurfaceData surfaceData = new SurfaceData();
+
+            //Create a couple of GameObjects for collision detection
+            GameObject front = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            front.transform.position = Vector3.forward * 5f;
+            GameObject bottom = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            bottom.transform.position = Vector3.down * 5f;
+
+            //Do an initial collision
+            Ray forwardRay = new Ray(Vector3.zero, Vector3.forward);
+            RaycastHit forwardHit;
+            Physics.Raycast(forwardRay, out forwardHit);
+
+            //Set up the initial collision of a surface
+            surfaceData.origin = Vector3.zero;
+            surfaceData.direction = Vector3.forward;
+            surfaceData.CollisionData = forwardHit;
+
+            //Do an second different collision
+            Ray downwardRay = new Ray(Vector3.zero, Vector3.down);
+            RaycastHit downwardHit;
+            Physics.Raycast(downwardRay, out downwardHit);
+
+            //Set up the initial collision of a surface
+            surfaceData.origin = Vector3.zero;
+            surfaceData.direction = Vector3.down;
+            surfaceData.CollisionData = downwardHit;
+
+            Assert.AreEqual(Vector3.zero, surfaceData.origin);
+            Assert.AreEqual(Vector3.down, surfaceData.direction);
+            Assert.AreEqual(bottom.transform, surfaceData.CollisionData.transform);
+            Assert.AreEqual(front.transform, surfaceData.PreviousCollisionData.transform);
+
+            Object.DestroyImmediate(front);
+            Object.DestroyImmediate(bottom);
+        }
+    }
+}

--- a/Tests/Editor/Data/Type/SurfaceDataTest.cs.meta
+++ b/Tests/Editor/Data/Type/SurfaceDataTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33158222833d01d499656d931680d5ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Data/Type/TransformDataTest.cs
+++ b/Tests/Editor/Data/Type/TransformDataTest.cs
@@ -1,0 +1,58 @@
+﻿namespace VRTK.Core.Data.Type
+{
+    using UnityEngine;
+    using NUnit.Framework;
+
+    public class TransformDataTest
+    {
+        [Test]
+        public void DefaultConstructor()
+        {
+            TransformData transformData = new TransformData();
+            Assert.IsNull(transformData.transform);
+        }
+
+        [Test]
+        public void TransformConstructor()
+        {
+            Transform defaultTransform = new GameObject().transform;
+            TransformData transformData = new TransformData(defaultTransform);
+            Assert.AreEqual(defaultTransform, transformData.transform);
+            Object.DestroyImmediate(defaultTransform.gameObject);
+        }
+
+        [Test]
+        public void OverridePosition()
+        {
+            Transform defaultTransform = new GameObject().transform;
+            TransformData transformData = new TransformData(defaultTransform);
+            Assert.AreEqual(Vector3.zero, transformData.Position);
+            transformData.positionOverride = Vector3.one;
+            Assert.AreEqual(Vector3.one, transformData.Position);
+            Object.DestroyImmediate(defaultTransform.gameObject);
+        }
+
+        [Test]
+        public void OverrideRotation()
+        {
+            Transform defaultTransform = new GameObject().transform;
+            TransformData transformData = new TransformData(defaultTransform);
+            Quaternion rotationOverride = new Quaternion(1f, 1f, 1f, 0f);
+            Assert.AreEqual(Quaternion.identity, transformData.Rotation);
+            transformData.rotationOverride = rotationOverride;
+            Assert.AreEqual(rotationOverride, transformData.Rotation);
+            Object.DestroyImmediate(defaultTransform.gameObject);
+        }
+
+        [Test]
+        public void OverrideScale()
+        {
+            Transform defaultTransform = new GameObject().transform;
+            TransformData transformData = new TransformData(defaultTransform);
+            Assert.AreEqual(Vector3.one, transformData.LocalScale);
+            transformData.localScaleOverride = Vector3.zero;
+            Assert.AreEqual(Vector3.zero, transformData.LocalScale);
+            Object.DestroyImmediate(defaultTransform.gameObject);
+        }
+    }
+}

--- a/Tests/Editor/Data/Type/TransformDataTest.cs.meta
+++ b/Tests/Editor/Data/Type/TransformDataTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94f2ddbd0b8b7fd44890f5ca96bdc639
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Extension.meta
+++ b/Tests/Editor/Extension.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 125ba1fcbcef72a49bf455c0cfecbae5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Extension/ComponentExtensionsTest.cs
+++ b/Tests/Editor/Extension/ComponentExtensionsTest.cs
@@ -1,0 +1,24 @@
+﻿namespace VRTK.Core.Extension
+{
+    using UnityEngine;
+    using NUnit.Framework;
+
+    public class ComponentExtensionsTest
+    {
+        [Test]
+        public void TryGetTransformValid()
+        {
+            Transform validTransform = new GameObject().transform;
+            Assert.NotNull(validTransform.TryGetTransform());
+            Object.DestroyImmediate(validTransform.gameObject);
+        }
+
+        [Test]
+        public void TryGetTransformInvalid()
+        {
+            Component invalidComponent = new Component();
+            Assert.IsNull(invalidComponent.TryGetTransform());
+            Object.DestroyImmediate(invalidComponent);
+        }
+    }
+}

--- a/Tests/Editor/Extension/ComponentExtensionsTest.cs.meta
+++ b/Tests/Editor/Extension/ComponentExtensionsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfb837d8157f9a844b093807a08715c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Extension/Vector3ExtensionsTest.cs
+++ b/Tests/Editor/Extension/Vector3ExtensionsTest.cs
@@ -1,0 +1,37 @@
+﻿namespace VRTK.Core.Extension
+{
+    using UnityEngine;
+    using NUnit.Framework;
+
+    public class Vector3ExtensionsTest
+    {
+        [Test]
+        public void CompareTrue()
+        {
+            Vector3 a = Vector3.zero;
+            Vector3 b = Vector3.zero;
+            float distance = 0f;
+
+            Assert.IsTrue(a.Compare(b, distance));
+
+            distance = 1f;
+            Assert.IsTrue(a.Compare(b, distance));
+
+            b = Vector3.one * 0.5f;
+            Assert.IsTrue(a.Compare(b, distance));
+        }
+
+        [Test]
+        public void CompareFalse()
+        {
+            Vector3 a = Vector3.zero;
+            Vector3 b = Vector3.one;
+            float distance = 0f;
+
+            Assert.IsFalse(a.Compare(b, distance));
+
+            distance = 1f;
+            Assert.IsFalse(a.Compare(b, distance));
+        }
+    }
+}

--- a/Tests/Editor/Extension/Vector3ExtensionsTest.cs.meta
+++ b/Tests/Editor/Extension/Vector3ExtensionsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9e0007eca27bbe4b814d45dbfe0f0cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Prefabs.meta
+++ b/Tests/Editor/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4edc994da90584479cc17d5bdc497ca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Prefabs/Pointers.meta
+++ b/Tests/Editor/Prefabs/Pointers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9a5225f7365b57a4cb31f64197e0d527
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Prefabs/Pointers/Straight.meta
+++ b/Tests/Editor/Prefabs/Pointers/Straight.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5e34437b959a5b429b2ef394776e8dc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Prefabs/Pointers/Straight/StraightPointerTest.cs
+++ b/Tests/Editor/Prefabs/Pointers/Straight/StraightPointerTest.cs
@@ -1,0 +1,471 @@
+﻿namespace VRTK.Core.Prefabs.Pointer
+{
+    using UnityEngine;
+    using NUnit.Framework;
+    using VRTK.Core.Utility.Mock;
+
+    public class StraightPointerTest
+    {
+        private GameObject containingObject;
+        private StraightPointerMock subject;
+
+        private GameObject validTracer;
+        private GameObject validCursor;
+        private GameObject invalidTracer;
+        private GameObject invalidCursor;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<StraightPointerMock>();
+
+            validTracer = new GameObject();
+            validCursor = new GameObject();
+            invalidTracer = new GameObject();
+            invalidCursor = new GameObject();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+
+            Object.DestroyImmediate(validTracer);
+            Object.DestroyImmediate(validCursor);
+            Object.DestroyImmediate(invalidTracer);
+            Object.DestroyImmediate(invalidCursor);
+        }
+
+        [Test]
+        public void ActivateAndDeactivate()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.cursorVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.activateOnEnable = false;
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+
+            subject.ManualOnEnable();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+
+            subject.Activate();
+            subject.ManualUpdate();
+
+            Assert.IsTrue(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+
+            GameObject blocker = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            blocker.transform.position = Vector3.forward * 5f;
+
+            subject.ManualUpdate();
+
+            Assert.IsTrue(validTracer.activeInHierarchy);
+            Assert.IsTrue(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+
+            activatedListenerMock.Reset();
+            subject.Deactivate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsTrue(deactivatedListenerMock.Received);
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+
+            Object.DestroyImmediate(blocker);
+        }
+
+        [Test]
+        public void Select()
+        {
+            UnityEventListenerMock selectListenerMock = new UnityEventListenerMock();
+
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.cursorVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.activateOnEnable = false;
+
+            subject.Selected.AddListener(selectListenerMock.Listen);
+
+            subject.ManualOnEnable();
+
+            Assert.IsFalse(selectListenerMock.Received);
+
+            subject.Activate();
+            subject.ManualUpdate();
+            subject.Select();
+
+            //Even though select is called, it isn't hitting a valid object so should be ignored.
+            Assert.IsFalse(selectListenerMock.Received);
+
+            //Place an object in the way to make a valid target
+            GameObject blocker = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            blocker.transform.position = Vector3.forward * 5f;
+
+            subject.ManualUpdate();
+            subject.Select();
+
+            //Now there is a valid object, select should be true.
+            Assert.IsTrue(selectListenerMock.Received);
+
+            Object.DestroyImmediate(blocker);
+        }
+
+        [Test]
+        public void TracerAlwaysVisible()
+        {
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.AlwaysOn;
+            subject.cursorVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.activateOnEnable = false;
+
+            subject.ManualOnEnable();
+            subject.ManualUpdate();
+
+            //Before activate is called the tracer should be true (not the valid one as there is no valid target).
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+
+            subject.Activate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+
+            subject.Deactivate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+        }
+
+        [Test]
+        public void CursorAlwaysVisible()
+        {
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.cursorVisibility = BasePointer.VisibilityType.AlwaysOn;
+            subject.activateOnEnable = false;
+
+            subject.ManualOnEnable();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+
+            subject.Activate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+
+            subject.Deactivate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+        }
+
+        [Test]
+        public void TracerAndCursorAlwaysVisible()
+        {
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.AlwaysOn;
+            subject.cursorVisibility = BasePointer.VisibilityType.AlwaysOn;
+            subject.activateOnEnable = false;
+
+            subject.ManualOnEnable();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+
+            subject.Activate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+
+            subject.Deactivate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+        }
+
+        [Test]
+        public void TracerAlwaysHidden()
+        {
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.AlwaysOff;
+            subject.cursorVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.activateOnEnable = false;
+
+            subject.ManualOnEnable();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+
+            subject.Activate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+
+            subject.Deactivate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+        }
+
+        [Test]
+        public void CursorAlwaysHidden()
+        {
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.cursorVisibility = BasePointer.VisibilityType.AlwaysOff;
+            subject.activateOnEnable = false;
+
+            subject.ManualOnEnable();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+
+            subject.Activate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+
+            subject.Deactivate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+        }
+
+        [Test]
+        public void TracerAndCursorAlwaysHidden()
+        {
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.AlwaysOff;
+            subject.cursorVisibility = BasePointer.VisibilityType.AlwaysOff;
+            subject.activateOnEnable = false;
+
+            subject.ManualOnEnable();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+
+            subject.Activate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+
+            subject.Deactivate();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsFalse(invalidTracer.activeInHierarchy);
+            Assert.IsFalse(invalidCursor.activeInHierarchy);
+        }
+
+        [Test]
+        public void ActiveOnEnable()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.cursorVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.activateOnEnable = true;
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+
+            subject.ManualOnEnable();
+            subject.ManualUpdate();
+
+            Assert.IsFalse(validTracer.activeInHierarchy);
+            Assert.IsFalse(validCursor.activeInHierarchy);
+            Assert.IsTrue(invalidTracer.activeInHierarchy);
+            Assert.IsTrue(invalidCursor.activeInHierarchy);
+
+            Assert.IsTrue(activatedListenerMock.Received);
+        }
+
+        [Test]
+        public void EnterExit()
+        {
+            UnityEventListenerMock enterListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock exitListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock hoverListenerMock = new UnityEventListenerMock();
+
+            subject.maximumLength = 100f;
+            subject.validTracer = validTracer;
+            subject.validCursor = validCursor;
+            subject.invalidTracer = invalidTracer;
+            subject.invalidCursor = invalidCursor;
+            subject.tracerVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.cursorVisibility = BasePointer.VisibilityType.OnWhenActive;
+            subject.activateOnEnable = false;
+
+            subject.Entered.AddListener(enterListenerMock.Listen);
+            subject.Exited.AddListener(exitListenerMock.Listen);
+            subject.Hovering.AddListener(hoverListenerMock.Listen);
+
+            subject.ManualOnEnable();
+
+            Assert.IsFalse(enterListenerMock.Received);
+            Assert.IsFalse(exitListenerMock.Received);
+            Assert.IsFalse(hoverListenerMock.Received);
+
+            subject.Activate();
+            subject.ManualUpdate();
+
+            //No valid target so still should be false
+            Assert.IsFalse(enterListenerMock.Received);
+            Assert.IsFalse(exitListenerMock.Received);
+            Assert.IsFalse(hoverListenerMock.Received);
+
+            //Place an object in the way to make a valid target
+            GameObject blocker = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            blocker.transform.position = Vector3.forward * 5f;
+
+            subject.ManualUpdate();
+
+            //The target should be entered and be hovered over
+            Assert.IsTrue(enterListenerMock.Received);
+            Assert.IsFalse(exitListenerMock.Received);
+            Assert.IsTrue(hoverListenerMock.Received);
+            Assert.AreEqual(blocker.transform, subject.CollisionData.transform);
+
+            enterListenerMock.Reset();
+            hoverListenerMock.Reset();
+
+            //Move the target
+            blocker.transform.position = Vector3.left * 10f;
+
+            subject.ManualUpdate();
+
+            Assert.IsFalse(enterListenerMock.Received);
+            Assert.IsTrue(exitListenerMock.Received);
+            Assert.IsFalse(hoverListenerMock.Received);
+
+            Assert.AreEqual(null, subject.CollisionData.transform);
+
+            Object.DestroyImmediate(blocker);
+        }
+    }
+
+    public class StraightPointerMock : StraightPointer
+    {
+        public void ManualOnEnable()
+        {
+            OnEnable();
+        }
+
+        public void ManualUpdate()
+        {
+            Update();
+        }
+    }
+}

--- a/Tests/Editor/Prefabs/Pointers/Straight/StraightPointerTest.cs.meta
+++ b/Tests/Editor/Prefabs/Pointers/Straight/StraightPointerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6decfec1489bc3d45bec27009bb6ff46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/SurfaceLocatorTest.cs
+++ b/Tests/Editor/Tracking/SurfaceLocatorTest.cs
@@ -1,0 +1,92 @@
+﻿namespace VRTK.Core.Tracking
+{
+    using UnityEngine;
+    using NUnit.Framework;
+    using System.Collections.Generic;
+    using VRTK.Core.Utility.Mock;
+    using VRTK.Core.Utility;
+
+    public class SurfaceLocatorTest
+    {
+        private GameObject containingObject;
+        private SurfaceLocator subject;
+        private GameObject validSurface;
+        private GameObject searchOrigin;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<SurfaceLocator>();
+            validSurface = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            searchOrigin = new GameObject();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+
+            Object.DestroyImmediate(validSurface);
+            Object.DestroyImmediate(searchOrigin);
+        }
+
+        [Test]
+        public void ValidSurface()
+        {
+            UnityEventListenerMock surfaceLocatedMock = new UnityEventListenerMock();
+            subject.SurfaceLocated.AddListener(surfaceLocatedMock.Listen);
+
+            validSurface.transform.position = Vector3.forward * 5f;
+
+            subject.searchOrigin = searchOrigin.transform;
+            subject.searchDirection = Vector3.forward;
+
+            //Process just calls Locate() so may as well just test the first point
+            subject.Process();
+
+            Assert.IsTrue(surfaceLocatedMock.Received);
+            Assert.AreEqual(subject.SurfaceData.transform, validSurface.transform);
+        }
+
+        [Test]
+        public void InvalidSurface()
+        {
+            UnityEventListenerMock surfaceLocatedMock = new UnityEventListenerMock();
+            subject.SurfaceLocated.AddListener(surfaceLocatedMock.Listen);
+
+            validSurface.transform.position = Vector3.forward * 5f;
+
+            subject.searchOrigin = searchOrigin.transform;
+            subject.searchDirection = Vector3.down;
+
+            subject.Locate();
+            Assert.IsFalse(surfaceLocatedMock.Received);
+        }
+
+        [Test]
+        public void InvalidSurfaceDueToPolicy()
+        {
+            UnityEventListenerMock surfaceLocatedMock = new UnityEventListenerMock();
+            subject.SurfaceLocated.AddListener(surfaceLocatedMock.Listen);
+
+            validSurface.transform.position = Vector3.forward * 5f;
+            validSurface.AddComponent<PolicyTest>();
+            ExclusionRule exclusions = validSurface.AddComponent<ExclusionRule>();
+            exclusions.checkType = ExclusionRule.CheckTypes.Script;
+            exclusions.identifiers = new List<string>() { "PolicyTest" };
+
+            subject.searchOrigin = searchOrigin.transform;
+            subject.searchDirection = Vector3.forward;
+            subject.exclusionRule = exclusions;
+
+            subject.Locate();
+            Assert.IsFalse(surfaceLocatedMock.Received);
+        }
+    }
+
+    public class PolicyTest : MonoBehaviour
+    {
+    }
+}

--- a/Tests/Editor/Tracking/SurfaceLocatorTest.cs.meta
+++ b/Tests/Editor/Tracking/SurfaceLocatorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3322224b52b821499ad42d1d2be0b92
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/TransformModifyTest.cs
+++ b/Tests/Editor/Tracking/TransformModifyTest.cs
@@ -12,6 +12,7 @@
         private GameObject sourceObject;
         private GameObject offsetObject;
         private GameObject targetObject;
+        private TransformData targetTransformData;
 
         [SetUp]
         public void SetUp()
@@ -22,6 +23,7 @@
             sourceObject = new GameObject();
             offsetObject = new GameObject();
             targetObject = new GameObject();
+            targetTransformData = new TransformData(targetObject.transform);
         }
 
         [TearDown]
@@ -38,13 +40,14 @@
         [Test]
         public void ModifyPositionNoOffsetInstantTransition()
         {
-            targetObject.transform.position = Vector3.one;
+
+            targetTransformData.transform.position = Vector3.one;
 
             subject.source = sourceObject.transform;
             subject.applyTransformations = Data.Enum.TransformProperties.Position;
 
             Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
-            subject.Modify(targetObject.transform);
+            subject.Modify(targetTransformData);
             Assert.AreEqual(Vector3.one, sourceObject.transform.position);
         }
 
@@ -52,15 +55,15 @@
         public void ModifyRotationNoOffsetInstantTransition()
         {
             Quaternion targetRotation = new Quaternion(1f, 0f, 0f, 0f);
-            targetObject.transform.position = Vector3.one;
-            targetObject.transform.rotation = targetRotation;
+            targetTransformData.transform.position = Vector3.one;
+            targetTransformData.transform.rotation = targetRotation;
 
             subject.source = sourceObject.transform;
             subject.applyTransformations = Data.Enum.TransformProperties.Rotation;
 
             Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
             Assert.AreEqual(Quaternion.identity, sourceObject.transform.rotation);
-            subject.Modify(targetObject.transform);
+            subject.Modify(targetTransformData);
             Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
             Assert.AreEqual(targetRotation, sourceObject.transform.rotation);
         }
@@ -68,9 +71,9 @@
         [Test]
         public void ModifyScaleNoOffsetInstantTransition()
         {
-            targetObject.transform.position = Vector3.one;
-            targetObject.transform.rotation = new Quaternion(1f, 0f, 0f, 0f);
-            targetObject.transform.localScale = Vector3.one * 2f;
+            targetTransformData.transform.position = Vector3.one;
+            targetTransformData.transform.rotation = new Quaternion(1f, 0f, 0f, 0f);
+            targetTransformData.transform.localScale = Vector3.one * 2f;
 
             subject.source = sourceObject.transform;
             subject.applyTransformations = Data.Enum.TransformProperties.Scale;
@@ -78,7 +81,7 @@
             Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
             Assert.AreEqual(Quaternion.identity, sourceObject.transform.rotation);
             Assert.AreEqual(Vector3.one, sourceObject.transform.localScale);
-            subject.Modify(targetObject.transform);
+            subject.Modify(targetTransformData);
             Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
             Assert.AreEqual(Quaternion.identity, sourceObject.transform.rotation);
             Assert.AreEqual(Vector3.one * 2f, sourceObject.transform.localScale);
@@ -90,15 +93,15 @@
             offsetObject.transform.position = Vector3.one;
             offsetObject.transform.rotation = new Quaternion(0.5f, 0f, 0.5f, 0f);
 
-            targetObject.transform.position = Vector3.one * 2f;
-            targetObject.transform.rotation = new Quaternion(1f, 1f, 0f, 0f);
-            targetObject.transform.localScale = Vector3.one * 3f;
+            targetTransformData.transform.position = Vector3.one * 2f;
+            targetTransformData.transform.rotation = new Quaternion(1f, 1f, 0f, 0f);
+            targetTransformData.transform.localScale = Vector3.one * 3f;
 
             subject.source = sourceObject.transform;
             subject.offset = offsetObject.transform;
             subject.applyTransformations = Data.Enum.TransformProperties.Position | Data.Enum.TransformProperties.Rotation | Data.Enum.TransformProperties.Scale;
 
-            subject.Modify(targetObject.transform);
+            subject.Modify(targetTransformData);
             Assert.AreEqual(new Vector3(-1f, -1f, 5f).ToString(), sourceObject.transform.position.ToString());
             Assert.AreEqual(new Quaternion(0.7f, 0.7f, 0f, 0f).ToString(), sourceObject.transform.rotation.ToString());
             Assert.AreEqual(Vector3.one * 3f, sourceObject.transform.localScale);
@@ -110,16 +113,16 @@
             offsetObject.transform.position = Vector3.one;
             offsetObject.transform.rotation = new Quaternion(0.5f, 0f, 0.5f, 0f);
 
-            targetObject.transform.position = Vector3.one * 2f;
-            targetObject.transform.rotation = new Quaternion(1f, 1f, 0f, 0f);
-            targetObject.transform.localScale = Vector3.one * 3f;
+            targetTransformData.transform.position = Vector3.one * 2f;
+            targetTransformData.transform.rotation = new Quaternion(1f, 1f, 0f, 0f);
+            targetTransformData.transform.localScale = Vector3.one * 3f;
 
             subject.source = sourceObject.transform;
             subject.offset = offsetObject.transform;
             subject.applyOffsetOnAxis = new Vector3State(true, false, false);
             subject.applyTransformations = Data.Enum.TransformProperties.Position | Data.Enum.TransformProperties.Rotation | Data.Enum.TransformProperties.Scale;
 
-            subject.Modify(targetObject.transform);
+            subject.Modify(targetTransformData);
             Assert.AreEqual(new Vector3(2f, -1f, 2f).ToString(), sourceObject.transform.position.ToString());
             Assert.AreEqual(new Quaternion(0.7f, 0.7f, 0f, 0f).ToString(), sourceObject.transform.rotation.ToString());
             Assert.AreEqual(Vector3.one * 3f, sourceObject.transform.localScale);
@@ -128,11 +131,11 @@
         [Test]
         public void ModifyTransformNoSource()
         {
-            targetObject.transform.position = Vector3.one * 2f;
-            targetObject.transform.rotation = new Quaternion(1f, 1f, 0f, 0f);
-            targetObject.transform.localScale = Vector3.one * 3f;
+            targetTransformData.transform.position = Vector3.one * 2f;
+            targetTransformData.transform.rotation = new Quaternion(1f, 1f, 0f, 0f);
+            targetTransformData.transform.localScale = Vector3.one * 3f;
 
-            subject.Modify(targetObject.transform);
+            subject.Modify(targetTransformData);
             Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
             Assert.AreEqual(Quaternion.identity, sourceObject.transform.rotation);
             Assert.AreEqual(Vector3.one, sourceObject.transform.localScale);

--- a/Tests/Editor/Utility.meta
+++ b/Tests/Editor/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 83a9099ef6dd85f49981adc3e5a286b6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Utility/ExclusionRuleTest.cs
+++ b/Tests/Editor/Utility/ExclusionRuleTest.cs
@@ -1,0 +1,233 @@
+﻿namespace VRTK.Core.Utility
+{
+    using UnityEngine;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
+    public class ExclusionRuleTest
+    {
+        private GameObject containingObject;
+        private ExclusionRule subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<ExclusionRule>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void CheckIgnoreTag()
+        {
+            string tag = GetValidTag();
+            subject.operation = ExclusionRule.OperationType.Ignore;
+            subject.checkType = ExclusionRule.CheckTypes.Tag;
+            subject.identifiers = new List<string>() { tag };
+
+            GameObject includeObject = new GameObject();
+            GameObject ignoreObject = new GameObject
+            {
+                tag = tag
+            };
+
+            //The PolicyExclusionList is an Ignore type so anything not in the ignore list shouldn't be excluded so will return false.
+            Assert.IsFalse(subject.ShouldExclude(includeObject));
+            Assert.IsFalse(ExclusionRule.ShouldExclude(includeObject, subject));
+            //And anything in the ignore list should be excluded so will return true.
+            Assert.IsTrue(subject.ShouldExclude(ignoreObject));
+            Assert.IsTrue(ExclusionRule.ShouldExclude(ignoreObject, subject));
+        }
+
+        [Test]
+        public void CheckIncludeTag()
+        {
+            string tag = GetValidTag();
+            subject.operation = ExclusionRule.OperationType.Include;
+            subject.checkType = ExclusionRule.CheckTypes.Tag;
+            subject.identifiers = new List<string>() { tag };
+
+            GameObject ignoreObject = new GameObject();
+            GameObject includeObject = new GameObject
+            {
+                tag = tag
+            };
+
+            //The PolicyExclusionList is an Include type so anything in the list shouldn't be excluded so will return false.
+            Assert.IsFalse(subject.ShouldExclude(includeObject));
+            Assert.IsFalse(ExclusionRule.ShouldExclude(includeObject, subject));
+            //And anything not in the list should be excluded so will return true.
+            Assert.IsTrue(subject.ShouldExclude(ignoreObject));
+            Assert.IsTrue(ExclusionRule.ShouldExclude(ignoreObject, subject));
+        }
+
+        [Test]
+        public void CheckIgnoreTags()
+        {
+            string tag1 = GetValidTag(1);
+            string tag2 = GetValidTag(2);
+
+            subject.operation = ExclusionRule.OperationType.Ignore;
+            subject.checkType = ExclusionRule.CheckTypes.Tag;
+            subject.identifiers = new List<string>() { tag1, tag2 };
+
+            GameObject includeObject = new GameObject();
+            GameObject ignoreObject1 = new GameObject
+            {
+                tag = tag1
+            };
+            GameObject ignoreObject2 = new GameObject
+            {
+                tag = tag2
+            };
+
+            //The PolicyExclusionList is an Ignore type so anything not in the ignore list shouldn't be excluded so will return false.
+            Assert.IsFalse(subject.ShouldExclude(includeObject));
+            Assert.IsFalse(ExclusionRule.ShouldExclude(includeObject, subject));
+            //And anything in the ignore list should be excluded so will return true.
+            Assert.IsTrue(subject.ShouldExclude(ignoreObject1));
+            Assert.IsTrue(ExclusionRule.ShouldExclude(ignoreObject1, subject));
+            Assert.IsTrue(subject.ShouldExclude(ignoreObject2));
+            Assert.IsTrue(ExclusionRule.ShouldExclude(ignoreObject2, subject));
+        }
+
+        [Test]
+        public void CheckIncludeTags()
+        {
+            string tag1 = GetValidTag(1);
+            string tag2 = GetValidTag(2);
+
+            subject.operation = ExclusionRule.OperationType.Include;
+            subject.checkType = ExclusionRule.CheckTypes.Tag;
+            subject.identifiers = new List<string>() { tag1, tag2 };
+
+            GameObject ignoreObject = new GameObject();
+            GameObject includeObject1 = new GameObject
+            {
+                tag = tag1
+            };
+            GameObject includeObject2 = new GameObject
+            {
+                tag = tag2
+            };
+
+            //The PolicyExclusionList is an Include type so anything in the list shouldn't be excluded so will return false.
+            Assert.IsFalse(subject.ShouldExclude(includeObject1));
+            Assert.IsFalse(ExclusionRule.ShouldExclude(includeObject1, subject));
+            Assert.IsFalse(subject.ShouldExclude(includeObject2));
+            Assert.IsFalse(ExclusionRule.ShouldExclude(includeObject2, subject));
+            //And anything not in the list should be excluded so will return true.
+            Assert.IsTrue(subject.ShouldExclude(ignoreObject));
+            Assert.IsTrue(ExclusionRule.ShouldExclude(ignoreObject, subject));
+        }
+
+        [Test]
+        public void CheckIgnoreScript()
+        {
+
+            subject.operation = ExclusionRule.OperationType.Ignore;
+            subject.checkType = ExclusionRule.CheckTypes.Script;
+            subject.identifiers = new List<string>() { "PolicyExclusionTestScript" };
+
+            GameObject includeObject = new GameObject();
+            GameObject ignoreObject = new GameObject();
+            ignoreObject.AddComponent<PolicyExclusionTestScript>();
+
+            Assert.IsFalse(subject.ShouldExclude(includeObject));
+            Assert.IsFalse(ExclusionRule.ShouldExclude(includeObject, subject));
+            Assert.IsTrue(subject.ShouldExclude(ignoreObject));
+            Assert.IsTrue(ExclusionRule.ShouldExclude(ignoreObject, subject));
+        }
+
+        [Test]
+        public void CheckIncludeScript()
+        {
+            subject.operation = ExclusionRule.OperationType.Include;
+            subject.checkType = ExclusionRule.CheckTypes.Script;
+            subject.identifiers = new List<string>() { "PolicyExclusionTestScript" };
+
+            GameObject includeObject = new GameObject();
+            includeObject.AddComponent<PolicyExclusionTestScript>();
+            GameObject ignoreObject = new GameObject();
+
+            Assert.IsFalse(subject.ShouldExclude(includeObject));
+            Assert.IsFalse(ExclusionRule.ShouldExclude(includeObject, subject));
+            Assert.IsTrue(subject.ShouldExclude(ignoreObject));
+            Assert.IsTrue(ExclusionRule.ShouldExclude(ignoreObject, subject));
+        }
+
+        [Test]
+        public void CheckIgnoreLayer()
+        {
+            string layer = GetValidLayer();
+            subject.operation = ExclusionRule.OperationType.Ignore;
+            subject.checkType = ExclusionRule.CheckTypes.Layer;
+            subject.identifiers = new List<string>() { layer };
+
+            GameObject includeObject = new GameObject();
+            GameObject ignoreObject = new GameObject
+            {
+                layer = LayerMask.NameToLayer(layer)
+            };
+
+            Assert.IsFalse(subject.ShouldExclude(includeObject));
+            Assert.IsFalse(ExclusionRule.ShouldExclude(includeObject, subject));
+            Assert.IsTrue(subject.ShouldExclude(ignoreObject));
+            Assert.IsTrue(ExclusionRule.ShouldExclude(ignoreObject, subject));
+        }
+
+        [Test]
+        public void CheckIncludeLayer()
+        {
+            string layer = GetValidLayer();
+            subject.operation = ExclusionRule.OperationType.Include;
+            subject.checkType = ExclusionRule.CheckTypes.Layer;
+            subject.identifiers = new List<string>() { layer };
+
+            GameObject ignoreObject = new GameObject();
+            GameObject includeObject = new GameObject
+            {
+                layer = LayerMask.NameToLayer(layer)
+            };
+
+            Assert.IsFalse(subject.ShouldExclude(includeObject));
+            Assert.IsFalse(ExclusionRule.ShouldExclude(includeObject, subject));
+            Assert.IsTrue(subject.ShouldExclude(ignoreObject));
+            Assert.IsTrue(ExclusionRule.ShouldExclude(ignoreObject, subject));
+        }
+
+        private string GetValidTag(int index = 1)
+        {
+            if (UnityEditorInternal.InternalEditorUtility.tags.Length > index)
+            {
+                return UnityEditorInternal.InternalEditorUtility.tags[index];
+            }
+            else
+            {
+                throw new MissingReferenceException("No Unity Tags have been defined.");
+            }
+        }
+
+        private string GetValidLayer(int index = 1)
+        {
+            if (UnityEditorInternal.InternalEditorUtility.layers.Length > index)
+            {
+                return UnityEditorInternal.InternalEditorUtility.layers[index];
+            }
+            else
+            {
+                throw new MissingReferenceException("No Unity Layers have been defined.");
+            }
+        }
+    }
+
+    public class PolicyExclusionTestScript : MonoBehaviour
+    {
+    }
+}

--- a/Tests/Editor/Utility/ExclusionRuleTest.cs.meta
+++ b/Tests/Editor/Utility/ExclusionRuleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 822630ab2ccbaf14984b8a482577d485
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The pointer concept is the ability to designate an area of the scene
with a destination. The Straight Pointer implementation of the pointer
casts a straight beam from an origin point (e.g. controller) and stops
when it collides with an object (or reaches the set maximum length).

A pointer knows when it is activated, deactivated, when it starts
hovering (enters) a new object, when it finishes hovering (exits)
an object and knows what coordinates of the object it is hovering
over. These are all cast as events with a special pointer payload
containing information about the pointer target.

The RayCast emitted by Straight Pointer can be customised by utilising
a PhysicsCast object which is a MonoBehaviour component that allows
edit time configuration of a Physics Cast and can then be injected
into the Pointer script. This can allow optional configuration
such as choosing which layers to ignore and whether to ignore
trigger colliders.