### PR TITLE
fix(Process): unnecessary serialization annotation

### DIFF
--- a/Scripts/Process/MomentProcess.cs
+++ b/Scripts/Process/MomentProcess.cs
@@ -1,14 +1,12 @@
 ﻿namespace VRTK.Core.Process
 {
     using UnityEngine;
-    using System;
 
     /// <summary>
     /// The MomentProcess is a wrapper for an IProcessable process that has a state to determine when it is to be processed.
     /// </summary>
     public sealed class MomentProcess : MonoBehaviour
     {
-        [SerializeField]
         [Tooltip("The process to attach to the moment.")]
         public ProcessContainer process;
         [Tooltip("Only run the process if the process is on an active GameObject and the component is enabled.")]


### PR DESCRIPTION
The `MomentProcess` was using a C# attribute to annotate a field to
serialize it. This is unnecessary because the field is already
public and the class inherits from `MonoBehaviour`.