### PR TITLE
feat(Tracking): mirror game object active state to other game objects

### DIFF
--- a/Scripts/Tracking/GameObjectStateMirror.cs
+++ b/Scripts/Tracking/GameObjectStateMirror.cs
@@ -1,0 +1,29 @@
+﻿namespace VRTK.Core.Tracking
+{
+    using UnityEngine;
+    using VRTK.Core.Process;
+
+    /// <summary>
+    /// The GameObjectStateMirror mirrors the active state of the source GameObject across all of the given target GameObjects.
+    /// </summary>
+    public class GameObjectStateMirror : SourceTargetProcessor
+    {
+        /// <summary>
+        /// The Process method executes the relevant process.
+        /// </summary>
+        public override void Process()
+        {
+            ProcessAllComponents();
+        }
+
+        /// <summary>
+        /// The ProcessComponent method sets all of the target GameObjects states to match the source GameObject state.
+        /// </summary>
+        /// <param name="source">The source Component that is a Transform.</param>
+        /// <param name="target">The target Component that is a Transform.</param>
+        protected override void ProcessComponent(Component source, Component target)
+        {
+            target.gameObject.SetActive(source.gameObject.activeInHierarchy);
+        }
+    }
+}

--- a/Scripts/Tracking/GameObjectStateMirror.cs.meta
+++ b/Scripts/Tracking/GameObjectStateMirror.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac2aba98fe11f5d429cd8ad1517c907c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/GameObjectStateMirrorTest.cs
+++ b/Tests/Editor/Tracking/GameObjectStateMirrorTest.cs
@@ -1,0 +1,139 @@
+﻿namespace VRTK.Core.Tracking
+{
+    using UnityEngine;
+    using NUnit.Framework;
+
+    public class GameObjectStateMirrorTest
+    {
+        private GameObject containingObject;
+        private GameObjectStateMirror subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<GameObjectStateMirror>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void ActivateTargets()
+        {
+            GameObject source = new GameObject();
+            GameObject target1 = new GameObject();
+            GameObject target2 = new GameObject();
+            GameObject target3 = new GameObject();
+
+            subject.sourceComponent = source.GetComponent<Component>();
+            subject.targetComponents = new Component[]
+            {
+                target1.GetComponent<Component>(),
+                target2.GetComponent<Component>(),
+                target3.GetComponent<Component>()
+            };
+
+            source.gameObject.SetActive(true);
+
+            target1.gameObject.SetActive(true);
+            target2.gameObject.SetActive(false);
+            target3.gameObject.SetActive(false);
+
+            Assert.IsTrue(source.gameObject.activeInHierarchy);
+            Assert.IsTrue(target1.gameObject.activeInHierarchy);
+            Assert.IsFalse(target2.gameObject.activeInHierarchy);
+            Assert.IsFalse(target3.gameObject.activeInHierarchy);
+
+            subject.Process();
+
+            Assert.IsTrue(source.gameObject.activeInHierarchy);
+            Assert.IsTrue(target1.gameObject.activeInHierarchy);
+            Assert.IsTrue(target2.gameObject.activeInHierarchy);
+            Assert.IsTrue(target3.gameObject.activeInHierarchy);
+        }
+
+        [Test]
+        public void DeactivateTargets()
+        {
+            GameObject source = new GameObject();
+            GameObject target1 = new GameObject();
+            GameObject target2 = new GameObject();
+            GameObject target3 = new GameObject();
+
+            subject.sourceComponent = source.GetComponent<Component>();
+            subject.targetComponents = new Component[]
+            {
+                target1.GetComponent<Component>(),
+                target2.GetComponent<Component>(),
+                target3.GetComponent<Component>()
+            };
+
+            source.gameObject.SetActive(false);
+
+            target1.gameObject.SetActive(true);
+            target2.gameObject.SetActive(false);
+            target3.gameObject.SetActive(true);
+
+            Assert.IsFalse(source.gameObject.activeInHierarchy);
+            Assert.IsTrue(target1.gameObject.activeInHierarchy);
+            Assert.IsFalse(target2.gameObject.activeInHierarchy);
+            Assert.IsTrue(target3.gameObject.activeInHierarchy);
+
+            subject.Process();
+
+            Assert.IsFalse(source.gameObject.activeInHierarchy);
+            Assert.IsFalse(target1.gameObject.activeInHierarchy);
+            Assert.IsFalse(target2.gameObject.activeInHierarchy);
+            Assert.IsFalse(target3.gameObject.activeInHierarchy);
+        }
+
+        [Test]
+        public void ActivateThenDeactivateTargets()
+        {
+            GameObject source = new GameObject();
+            GameObject target1 = new GameObject();
+            GameObject target2 = new GameObject();
+            GameObject target3 = new GameObject();
+
+            subject.sourceComponent = source.GetComponent<Component>();
+            subject.targetComponents = new Component[]
+            {
+                target1.GetComponent<Component>(),
+                target2.GetComponent<Component>(),
+                target3.GetComponent<Component>()
+            };
+
+            source.gameObject.SetActive(true);
+
+            target1.gameObject.SetActive(true);
+            target2.gameObject.SetActive(false);
+            target3.gameObject.SetActive(false);
+
+            Assert.IsTrue(source.gameObject.activeInHierarchy);
+            Assert.IsTrue(target1.gameObject.activeInHierarchy);
+            Assert.IsFalse(target2.gameObject.activeInHierarchy);
+            Assert.IsFalse(target3.gameObject.activeInHierarchy);
+
+            subject.Process();
+
+            Assert.IsTrue(source.gameObject.activeInHierarchy);
+            Assert.IsTrue(target1.gameObject.activeInHierarchy);
+            Assert.IsTrue(target2.gameObject.activeInHierarchy);
+            Assert.IsTrue(target3.gameObject.activeInHierarchy);
+
+            source.gameObject.SetActive(false);
+
+            subject.Process();
+
+            Assert.IsFalse(source.gameObject.activeInHierarchy);
+            Assert.IsFalse(target1.gameObject.activeInHierarchy);
+            Assert.IsFalse(target2.gameObject.activeInHierarchy);
+            Assert.IsFalse(target3.gameObject.activeInHierarchy);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/GameObjectStateMirrorTest.cs.meta
+++ b/Tests/Editor/Tracking/GameObjectStateMirrorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76487e579d6eeb242a850ce5ea416c52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The GameObjectStateMirror allows for a source GameObject active state
to control the active states of a collection of target GameObjects.

As it is a Process it requires to be added to a MomentProcessor to
execute.