### PR TITLE
feat(XrRelation): (de)activating game objects based on XR device - resolves #13

### DIFF
--- a/Scripts/Tracking/XrDeviceRelationActivator.cs
+++ b/Scripts/Tracking/XrDeviceRelationActivator.cs
@@ -1,0 +1,107 @@
+﻿namespace VRTK.Core.Tracking
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using UnityEngine;
+    using UnityEngine.XR;
+
+    /// <summary>
+    /// The XrDeviceRelationActivator activates and deactivates GameObjects based on the currently loaded XR device automatically and allows to override the active GameObject manually.
+    /// </summary>
+    public class XrDeviceRelationActivator : MonoBehaviour
+    {
+        /// <summary>
+        /// The XrDeviceRelation allows specifying a GameObject that will be (de)activated based on the XR device name.
+        /// </summary>
+        [Serializable]
+        public class XrDeviceRelation
+        {
+            [Tooltip("The name of the XR device that needs to be loaded for this relation to be activated.")]
+            public string xrDeviceName;
+            [Tooltip("The GameObjects to (de)activate.")]
+            public GameObject[] gameObjects;
+        }
+
+        [Tooltip("The relations in order they will be activated if their XR device name matches the currently loaded one.")]
+        public XrDeviceRelation[] relations = Array.Empty<XrDeviceRelation>();
+
+        protected XrDeviceRelation currentRelation;
+
+        /// <summary>
+        /// The Activate method activates the GameObject that is part of the relation if the XR device name matches the currently loaded one.
+        /// </summary>
+        /// <param name="relation">The relation to try to activate.</param>
+        public virtual void Activate(XrDeviceRelation relation)
+        {
+            if (currentRelation == relation)
+            {
+                return;
+            }
+
+            string loadedDeviceName = GetLoadedDeviceName();
+            if (relation.xrDeviceName != loadedDeviceName)
+            {
+                throw new ArgumentException($"The specified XR device named '{relation.xrDeviceName}' isn't loaded. The currently loaded XR device is named '{loadedDeviceName}' instead.", nameof(relation));
+            }
+
+            currentRelation = relation;
+
+            IEnumerable<XrDeviceRelation> otherRelations = relations.Except(
+                new[]
+                {
+                    relation
+                });
+            foreach (GameObject relationObject in otherRelations.SelectMany(otherRelation => otherRelation.gameObjects))
+            {
+                relationObject.SetActive(false);
+            }
+
+            foreach (GameObject relationObject in relation.gameObjects)
+            {
+                relationObject.SetActive(true);
+            }
+        }
+
+        /// <summary>
+        /// Deactivates the relation that is currently activated in addition to all other known relations.
+        /// </summary>
+        public virtual void Deactivate()
+        {
+            foreach (GameObject relationObject in relations.Append(currentRelation).Where(relation => relation != null).SelectMany(relation => relation.gameObjects).Where(relationObject => relationObject != null))
+            {
+                relationObject.SetActive(false);
+            }
+
+            currentRelation = null;
+        }
+
+        protected virtual void Awake()
+        {
+            if (relations.Any(relation => relation.gameObjects.Any(relationObject => relationObject.activeInHierarchy)))
+            {
+                Debug.LogWarning($"At least one relation object is active in the scene on {nameof(Awake)} of this {nameof(XrDeviceRelationActivator)}. Having multiple relation objects active at the same time will most likely lead to issues. Make sure to deactivate them all before you play or create a build.");
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            Deactivate();
+        }
+
+        protected virtual void Update()
+        {
+            string loadedDeviceName = GetLoadedDeviceName();
+            XrDeviceRelation desiredRelation = relations.FirstOrDefault(relation => relation.xrDeviceName == loadedDeviceName);
+            if (desiredRelation != null)
+            {
+                Activate(desiredRelation);
+            }
+        }
+
+        protected virtual string GetLoadedDeviceName()
+        {
+            return XRSettings.loadedDeviceName;
+        }
+    }
+}

--- a/Scripts/Tracking/XrDeviceRelationActivator.cs.meta
+++ b/Scripts/Tracking/XrDeviceRelationActivator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f09ad384763386444b3a9b9bad3d80ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/XrDeviceRelationActivatorTest.cs
+++ b/Tests/Editor/Tracking/XrDeviceRelationActivatorTest.cs
@@ -1,0 +1,365 @@
+﻿namespace VRTK.Core.Tracking
+{
+    using System;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public class XrDeviceRelationActivatorTest
+    {
+        private GameObject containingObject;
+        private XrDeviceRelationActivatorMock subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<XrDeviceRelationActivatorMock>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (subject.relations != null)
+            {
+                foreach (GameObject gameObject in subject.relations.SelectMany(relation => relation.gameObjects))
+                {
+                    UnityEngine.Object.DestroyImmediate(gameObject);
+                }
+            }
+
+            UnityEngine.Object.DestroyImmediate(subject);
+            UnityEngine.Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void AwakeLogsWarningForMultipleActiveGameObjects()
+        {
+            const string xrDeviceName = "XR Device";
+
+            subject.xrDeviceName = xrDeviceName;
+            subject.relations = new[]
+            {
+                new XrDeviceRelationActivator.XrDeviceRelation
+                {
+                    xrDeviceName = xrDeviceName,
+                    gameObjects = new[]
+                    {
+                        new GameObject()
+                    }
+                },
+                new XrDeviceRelationActivator.XrDeviceRelation
+                {
+                    xrDeviceName = xrDeviceName,
+                    gameObjects = new[]
+                    {
+                        new GameObject()
+                    }
+                }
+            };
+
+            LogAssert.Expect(LogType.Warning, new Regex("multiple relation"));
+            subject.ManualAwake();
+        }
+
+        [Test]
+        public void OnDisableDeactivates()
+        {
+            Assert.IsFalse(subject.wasDeactivateCalled);
+            subject.ManualOnDisable();
+            Assert.IsTrue(subject.wasDeactivateCalled);
+        }
+
+        [Test]
+        public void ActivatesFirstListEntryThatMatchesDevice()
+        {
+            const string expectedXrDeviceName = "Expected Device";
+            const string unexpectedXrDeviceName = "Unexpected Device";
+            XrDeviceRelationActivator.XrDeviceRelation unexpectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = unexpectedXrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+            XrDeviceRelationActivator.XrDeviceRelation expectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = expectedXrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+
+            subject.xrDeviceName = expectedXrDeviceName;
+            subject.relations = new[]
+            {
+                unexpectedRelation,
+                expectedRelation
+            };
+
+            Assert.AreEqual(subject.CurrentRelation, null);
+
+            subject.ManualUpdate();
+
+            Assert.AreEqual(subject.CurrentRelation, expectedRelation);
+            Assert.AreNotEqual(subject.CurrentRelation, unexpectedRelation);
+
+            Assert.IsTrue(subject.CurrentRelation.gameObjects.All(relationObject => relationObject.activeInHierarchy));
+            Assert.IsTrue(
+                subject.relations.Except(
+                        new[]
+                        {
+                            subject.CurrentRelation
+                        })
+                    .All(relation => relation.gameObjects.All(relationObject => !relationObject.activeInHierarchy)));
+        }
+
+        [Test]
+        public void ManualActivateOfValidListEntry()
+        {
+            const string xrDeviceName = "XR Device";
+            XrDeviceRelationActivator.XrDeviceRelation unexpectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = xrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+            XrDeviceRelationActivator.XrDeviceRelation expectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = xrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+
+            subject.xrDeviceName = xrDeviceName;
+            subject.relations = new[]
+            {
+                unexpectedRelation,
+                expectedRelation
+            };
+
+            subject.ManualUpdate();
+            subject.Activate(expectedRelation);
+
+            Assert.AreEqual(subject.CurrentRelation, expectedRelation);
+            Assert.AreNotEqual(subject.CurrentRelation, unexpectedRelation);
+        }
+
+        [Test]
+        public void ManualActivateOfInvalidListEntry()
+        {
+            const string expectedXrDeviceName = "Expected Device";
+            const string unexpectedXrDeviceName = "Unexpected Device";
+            XrDeviceRelationActivator.XrDeviceRelation unexpectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = unexpectedXrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+            XrDeviceRelationActivator.XrDeviceRelation expectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = expectedXrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+
+            subject.xrDeviceName = expectedXrDeviceName;
+            subject.relations = new[]
+            {
+                unexpectedRelation,
+                expectedRelation
+            };
+
+            subject.ManualUpdate();
+
+            Assert.Throws<ArgumentException>(() => subject.Activate(unexpectedRelation));
+            Assert.AreEqual(subject.CurrentRelation, expectedRelation);
+            Assert.AreNotEqual(subject.CurrentRelation, unexpectedRelation);
+        }
+
+        [Test]
+        public void ManualActivateOfValidUnknownRelation()
+        {
+            const string xrDeviceName = "XR Device";
+            XrDeviceRelationActivator.XrDeviceRelation unexpectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = xrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+            XrDeviceRelationActivator.XrDeviceRelation expectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = xrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+
+            subject.xrDeviceName = xrDeviceName;
+            subject.relations = new[]
+            {
+                unexpectedRelation
+            };
+
+            subject.ManualUpdate();
+            subject.Activate(expectedRelation);
+
+            Assert.AreEqual(subject.CurrentRelation, expectedRelation);
+            Assert.AreNotEqual(subject.CurrentRelation, unexpectedRelation);
+        }
+
+        [Test]
+        public void ManualActivateOfInvalidUnknownRelation()
+        {
+            const string expectedXrDeviceName = "Expected Device";
+            const string unexpectedXrDeviceName = "Unexpected Device";
+            XrDeviceRelationActivator.XrDeviceRelation unexpectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = unexpectedXrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+            XrDeviceRelationActivator.XrDeviceRelation expectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = expectedXrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+
+            subject.xrDeviceName = expectedXrDeviceName;
+            subject.relations = new[]
+            {
+                expectedRelation
+            };
+
+            subject.ManualUpdate();
+
+            Assert.Throws<ArgumentException>(() => subject.Activate(unexpectedRelation));
+            Assert.AreEqual(subject.CurrentRelation, expectedRelation);
+            Assert.AreNotEqual(subject.CurrentRelation, unexpectedRelation);
+        }
+
+        [Test]
+        public void ActivatesFirstListEntryThatMatchesDeviceAfterLoadedXrDeviceChanged()
+        {
+            const string expectedXrDeviceName = "Expected Device";
+            const string unexpectedXrDeviceName = "Unexpected Device";
+            XrDeviceRelationActivator.XrDeviceRelation unexpectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = unexpectedXrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+            XrDeviceRelationActivator.XrDeviceRelation expectedRelation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = expectedXrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+
+            subject.xrDeviceName = unexpectedXrDeviceName;
+            subject.relations = new[]
+            {
+                unexpectedRelation,
+                expectedRelation
+            };
+
+            subject.ManualUpdate();
+            subject.xrDeviceName = expectedXrDeviceName;
+            subject.ManualUpdate();
+
+            Assert.AreEqual(subject.CurrentRelation, expectedRelation);
+            Assert.AreNotEqual(subject.CurrentRelation, unexpectedRelation);
+        }
+
+        [Test]
+        public void DeactivateDeactivatesAllListEntries()
+        {
+            const string xrDeviceName = "XR Device";
+            XrDeviceRelationActivator.XrDeviceRelation relation = new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = xrDeviceName,
+                gameObjects = new[]
+                {
+                    new GameObject()
+                }
+            };
+
+            subject.xrDeviceName = xrDeviceName;
+            subject.relations = new[]
+            {
+                relation
+            };
+
+            subject.ManualUpdate();
+            subject.ManualOnDisable();
+
+            Assert.AreEqual(subject.CurrentRelation, null);
+            Assert.AreNotEqual(subject.CurrentRelation, relation);
+            Assert.IsTrue(subject.relations.All(deviceRelation => deviceRelation.gameObjects.All(gameObject => !gameObject.activeInHierarchy)));
+        }
+    }
+
+    public class XrDeviceRelationActivatorMock : XrDeviceRelationActivator
+    {
+        public string xrDeviceName;
+        public bool wasDeactivateCalled;
+
+        public XrDeviceRelation CurrentRelation
+        {
+            get
+            {
+                return currentRelation;
+            }
+        }
+
+        public void ManualAwake()
+        {
+            Awake();
+        }
+
+        public void ManualOnDisable()
+        {
+            OnDisable();
+        }
+
+        public void ManualUpdate()
+        {
+            Update();
+        }
+
+        public override void Deactivate()
+        {
+            base.Deactivate();
+            wasDeactivateCalled = true;
+        }
+
+        protected override string GetLoadedDeviceName()
+        {
+            return xrDeviceName;
+        }
+    }
+}

--- a/Tests/Editor/Tracking/XrDeviceRelationActivatorTest.cs.meta
+++ b/Tests/Editor/Tracking/XrDeviceRelationActivatorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f34beb960186b6a4cbea22314d4e8574
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Supporting multiple devices and SDKs results in the need to activate
and deactivate device/SDK specific game objects like the camera
rigs. The `XrDeviceRelationActivator` added with this change allows
to specify a mapping from XR device name to game objects using a new
type `XrDeviceRelation` which are then automatically (de)activated
based on the currently loaded XR device in Unity. The activator
additionally allows to deactivate all relations or activate a
specific one manually.