### PR TITLE
fix(Tracking): ensure surface locator doesn't reset rotation

### DIFF
--- a/Scripts/Tracking/SurfaceLocator.cs
+++ b/Scripts/Tracking/SurfaceLocator.cs
@@ -94,6 +94,7 @@
         {
             if (givenOrigin != null && givenOrigin.Valid && CastRay(givenOrigin.Position, searchDirection) && PositionChanged(DISTANCE_VARIANCE))
             {
+                SurfaceData.rotationOverride = givenOrigin.Rotation;
                 OnSurfaceLocated(SurfaceData);
             }
         }
@@ -137,7 +138,6 @@
             {
                 SurfaceData.transform = SurfaceData.CollisionData.transform;
                 SurfaceData.positionOverride = SurfaceData.CollisionData.point;
-                SurfaceData.rotationOverride = Quaternion.identity;
                 return true;
             }
             return false;


### PR DESCRIPTION
The SurfaceLocator was always resetting the rotation to 0 but it
really should just use the existing rotation.