### PR TITLE
chore(events): prevent events and actions on disabled components

### DIFF
--- a/Scripts/Cast/PointsCast.cs
+++ b/Scripts/Cast/PointsCast.cs
@@ -88,7 +88,10 @@
 
         protected virtual void OnCastResultsChanged()
         {
-            CastResultsChanged?.Invoke(GetPayload(), this);
+            if (isActiveAndEnabled)
+            {
+                CastResultsChanged?.Invoke(GetPayload(), this);
+            }
         }
 
         /// <summary>

--- a/Scripts/Tracking/Follow/ObjectFollow.cs
+++ b/Scripts/Tracking/Follow/ObjectFollow.cs
@@ -83,66 +83,99 @@
         /// <inheritdoc />
         public override void Process()
         {
-            OnBeforeProcessed();
-            if (followModifier != null && followModifier.ProcessFirstAndActiveOnly())
+            if (isActiveAndEnabled)
             {
-                ProcessFirstActiveComponent();
+                OnBeforeProcessed();
+                if (followModifier != null && followModifier.ProcessFirstAndActiveOnly())
+                {
+                    ProcessFirstActiveComponent();
+                }
+                else
+                {
+                    ProcessAllComponents();
+                }
+                OnAfterProcessed();
             }
-            else
-            {
-                ProcessAllComponents();
-            }
-            OnAfterProcessed();
         }
 
         protected virtual void OnBeforeProcessed()
         {
-            BeforeProcessed?.Invoke(null, null, this);
+            if (isActiveAndEnabled)
+            {
+                BeforeProcessed?.Invoke(null, null, this);
+            }
         }
 
         protected virtual void OnAfterProcessed()
         {
-            AfterProcessed?.Invoke(null, null, this);
+            if (isActiveAndEnabled)
+            {
+                AfterProcessed?.Invoke(null, null, this);
+            }
         }
 
         protected virtual void OnBeforeTransformUpdated(Transform source, Transform target)
         {
-            BeforeTransformUpdated?.Invoke(source, target, this);
+            if (isActiveAndEnabled)
+            {
+                BeforeTransformUpdated?.Invoke(source, target, this);
+            }
         }
 
         protected virtual void OnAfterTransformUpdated(Transform source, Transform target)
         {
-            AfterTransformUpdated?.Invoke(source, target, this);
+            if (isActiveAndEnabled)
+            {
+                AfterTransformUpdated?.Invoke(source, target, this);
+            }
         }
 
         protected virtual void OnBeforePositionUpdated(Transform source, Transform target)
         {
-            BeforePositionUpdated?.Invoke(source, target, this);
+            if (isActiveAndEnabled)
+            {
+                BeforePositionUpdated?.Invoke(source, target, this);
+            }
         }
 
         protected virtual void OnAfterPositionUpdated(Transform source, Transform target)
         {
-            AfterPositionUpdated?.Invoke(source, target, this);
+            if (isActiveAndEnabled)
+            {
+                AfterPositionUpdated?.Invoke(source, target, this);
+            }
         }
 
         protected virtual void OnBeforeRotationUpdated(Transform source, Transform target)
         {
-            BeforeRotationUpdated?.Invoke(source, target, this);
+            if (isActiveAndEnabled)
+            {
+                BeforeRotationUpdated?.Invoke(source, target, this);
+            }
         }
 
         protected virtual void OnAfterRotationUpdated(Transform source, Transform target)
         {
-            AfterRotationUpdated?.Invoke(source, target, this);
+            if (isActiveAndEnabled)
+            {
+                AfterRotationUpdated?.Invoke(source, target, this);
+            }
         }
 
         protected virtual void OnBeforeScaleUpdated(Transform source, Transform target)
         {
-            BeforeScaleUpdated?.Invoke(source, target, this);
+            if (isActiveAndEnabled)
+            {
+                BeforeScaleUpdated?.Invoke(source, target, this);
+            }
         }
 
         protected virtual void OnAfterScaleUpdated(Transform source, Transform target)
         {
-            AfterScaleUpdated?.Invoke(source, target, this);
+            if (isActiveAndEnabled)
+            {
+                AfterScaleUpdated?.Invoke(source, target, this);
+            }
         }
 
         /// <inheritdoc />

--- a/Scripts/Tracking/SurfaceLocator.cs
+++ b/Scripts/Tracking/SurfaceLocator.cs
@@ -101,7 +101,10 @@
 
         protected virtual void OnSurfaceLocated(SurfaceData e)
         {
-            SurfaceLocated?.Invoke(e, this);
+            if (isActiveAndEnabled)
+            {
+                SurfaceLocated?.Invoke(e, this);
+            }
         }
 
         /// <summary>

--- a/Scripts/Visual/CameraColorOverlay.cs
+++ b/Scripts/Visual/CameraColorOverlay.cs
@@ -109,17 +109,26 @@
 
         protected virtual void OnColorOverlayAdded(Color color)
         {
-            ColorOverlayAdded?.Invoke(color, this);
+            if (isActiveAndEnabled)
+            {
+                ColorOverlayAdded?.Invoke(color, this);
+            }
         }
 
         protected virtual void OnColorOverlayRemoved(Color color)
         {
-            ColorOverlayRemoved?.Invoke(color, this);
+            if (isActiveAndEnabled)
+            {
+                ColorOverlayRemoved?.Invoke(color, this);
+            }
         }
 
         protected virtual void OnColorOverlayChanged(Color color)
         {
-            ColorOverlayChanged?.Invoke(color, this);
+            if (isActiveAndEnabled)
+            {
+                ColorOverlayChanged?.Invoke(color, this);
+            }
         }
 
         /// <summary>

--- a/Tests/Editor/Action/BooleanActionTest.cs
+++ b/Tests/Editor/Action/BooleanActionTest.cs
@@ -94,6 +94,62 @@
             subject.Receive(false, null);
             Assert.IsTrue(changedListenerMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.gameObject.SetActive(false);
+            subject.Receive(true, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            activatedListenerMock.Reset();
+            deactivatedListenerMock.Reset();
+            changedListenerMock.Reset();
+
+            subject.Receive(false, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.enabled = false;
+            subject.Receive(true, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            activatedListenerMock.Reset();
+            deactivatedListenerMock.Reset();
+            changedListenerMock.Reset();
+
+            subject.Receive(false, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
     }
 
     public class BooleanActionMock : BooleanAction

--- a/Tests/Editor/Action/CompoundAndActionTest.cs
+++ b/Tests/Editor/Action/CompoundAndActionTest.cs
@@ -212,6 +212,94 @@
             subject.ManualUpdate();
             Assert.IsTrue(changedListenerMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            MockAction actionA = containingObject.AddComponent<MockAction>();
+            MockAction actionB = containingObject.AddComponent<MockAction>();
+
+            actionA.SetState(false);
+            actionB.SetState(false);
+
+            subject.actions = new BaseAction[]
+            {
+                actionA,
+                actionB
+            };
+
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.gameObject.SetActive(false);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            subject.ManualUpdate();
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            actionA.SetState(true);
+            actionB.SetState(true);
+
+            subject.ManualUpdate();
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            MockAction actionA = containingObject.AddComponent<MockAction>();
+            MockAction actionB = containingObject.AddComponent<MockAction>();
+
+            actionA.SetState(false);
+            actionB.SetState(false);
+
+            subject.actions = new BaseAction[]
+            {
+                actionA,
+                actionB
+            };
+
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.enabled = false;
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            subject.ManualUpdate();
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            actionA.SetState(true);
+            actionB.SetState(true);
+
+            subject.ManualUpdate();
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
     }
 
     public class CompoundAndActionMock : CompoundAndAction

--- a/Tests/Editor/Action/FloatActionTest.cs
+++ b/Tests/Editor/Action/FloatActionTest.cs
@@ -119,6 +119,52 @@
             subject.Receive(0.2f, null);
             Assert.IsTrue(changedListenerMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.gameObject.SetActive(false);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            subject.Receive(1f, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.enabled = false;
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            subject.Receive(1f, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
     }
 
     public class FloatActionMock : FloatAction

--- a/Tests/Editor/Action/ToggleActionTest.cs
+++ b/Tests/Editor/Action/ToggleActionTest.cs
@@ -104,6 +104,52 @@
             subject.Receive(false, null);
             Assert.IsTrue(changedListenerMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.gameObject.SetActive(false);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            subject.Receive(true, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.enabled = false;
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            subject.Receive(true, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
     }
 
     public class ToggleActionMock : ToggleAction

--- a/Tests/Editor/Action/Vector2ActionTest.cs
+++ b/Tests/Editor/Action/Vector2ActionTest.cs
@@ -119,6 +119,52 @@
             subject.Receive(new Vector2(0.2f, 0.2f), null);
             Assert.IsTrue(changedListenerMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.gameObject.SetActive(false);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            subject.Receive(Vector2.one, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.Changed.AddListener(changedListenerMock.Listen);
+            subject.enabled = false;
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            subject.Receive(Vector2.one, null);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+        }
     }
 
     public class Vector2ActionMock : Vector2Action

--- a/Tests/Editor/Cast/ParabolicLineCastTest.cs
+++ b/Tests/Editor/Cast/ParabolicLineCastTest.cs
@@ -157,5 +157,69 @@
             Assert.IsNull(subject.TargetHit);
             Assert.IsTrue(castResultsChangedMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
+            subject.CastResultsChanged.AddListener(castResultsChangedMock.Listen);
+
+            validSurface.transform.position = Vector3.forward * 5f + Vector3.down * 4f;
+
+            subject.maximumLength = new Vector2(5f, 5f);
+            subject.segmentCount = 5;
+            subject.gameObject.SetActive(false);
+
+            subject.Process();
+
+            Vector3[] expectedPoints = new Vector3[]
+            {
+                Vector3.zero,
+                new Vector3(0f, -0.1f, 2.9f),
+                new Vector3(0f, -1.4f, 4.4f),
+                new Vector3(0f, -2.8f, 4.9f),
+                new Vector3(0f, validSurface.transform.position.y + (validSurface.transform.localScale.y / 2f), validSurface.transform.position.z)
+            };
+
+            for (int i = 0; i < subject.Points.Count; i++)
+            {
+                Assert.AreEqual(expectedPoints[i].ToString(), subject.Points[i].ToString(), "Index " + i);
+            }
+
+            Assert.AreEqual(validSurface.transform, subject.TargetHit.Value.transform);
+            Assert.IsFalse(castResultsChangedMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
+            subject.CastResultsChanged.AddListener(castResultsChangedMock.Listen);
+
+            validSurface.transform.position = Vector3.forward * 5f + Vector3.down * 4f;
+
+            subject.maximumLength = new Vector2(5f, 5f);
+            subject.segmentCount = 5;
+            subject.enabled = false;
+
+            subject.Process();
+
+            Vector3[] expectedPoints = new Vector3[]
+            {
+                Vector3.zero,
+                new Vector3(0f, -0.1f, 2.9f),
+                new Vector3(0f, -1.4f, 4.4f),
+                new Vector3(0f, -2.8f, 4.9f),
+                new Vector3(0f, validSurface.transform.position.y + (validSurface.transform.localScale.y / 2f), validSurface.transform.position.z)
+            };
+
+            for (int i = 0; i < subject.Points.Count; i++)
+            {
+                Assert.AreEqual(expectedPoints[i].ToString(), subject.Points[i].ToString(), "Index " + i);
+            }
+
+            Assert.AreEqual(validSurface.transform, subject.TargetHit.Value.transform);
+            Assert.IsFalse(castResultsChangedMock.Received);
+        }
     }
 }

--- a/Tests/Editor/Cast/StraightLineCastTest.cs
+++ b/Tests/Editor/Cast/StraightLineCastTest.cs
@@ -94,6 +94,48 @@
             Assert.IsNull(subject.TargetHit);
             Assert.IsTrue(castResultsChangedMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
+            subject.CastResultsChanged.AddListener(castResultsChangedMock.Listen);
+
+            validSurface.transform.position = Vector3.forward * 5f;
+
+            subject.ManualAwake();
+            subject.gameObject.SetActive(false);
+            subject.Process();
+
+            Vector3 expectedStart = Vector3.zero;
+            Vector3 expectedEnd = validSurface.transform.position - (Vector3.forward * (validSurface.transform.localScale.z / 2f));
+
+            Assert.AreEqual(expectedStart, subject.Points[0]);
+            Assert.AreEqual(expectedEnd, subject.Points[1]);
+            Assert.AreEqual(validSurface.transform, subject.TargetHit.Value.transform);
+            Assert.IsFalse(castResultsChangedMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
+            subject.CastResultsChanged.AddListener(castResultsChangedMock.Listen);
+
+            validSurface.transform.position = Vector3.forward * 5f;
+
+            subject.ManualAwake();
+            subject.enabled = false;
+            subject.Process();
+
+            Vector3 expectedStart = Vector3.zero;
+            Vector3 expectedEnd = validSurface.transform.position - (Vector3.forward * (validSurface.transform.localScale.z / 2f));
+
+            Assert.AreEqual(expectedStart, subject.Points[0]);
+            Assert.AreEqual(expectedEnd, subject.Points[1]);
+            Assert.AreEqual(validSurface.transform, subject.TargetHit.Value.transform);
+            Assert.IsFalse(castResultsChangedMock.Received);
+        }
     }
 
     public class StraightLineCastMock : StraightLineCast

--- a/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
@@ -373,6 +373,150 @@
             Assert.IsFalse(beforeScaleUpdatedMock.Received);
             Assert.IsFalse(afterScaleUpdatedMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock beforeProcessedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterProcessedMock = new UnityEventListenerMock();
+            UnityEventListenerMock beforeTransformUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterTransformUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock beforePositionUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterPositionUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock beforeRotationUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterRotationUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock beforeScaleUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterScaleUpdatedMock = new UnityEventListenerMock();
+
+            subject.BeforeProcessed.AddListener(beforeProcessedMock.Listen);
+            subject.AfterProcessed.AddListener(afterProcessedMock.Listen);
+            subject.BeforeTransformUpdated.AddListener(beforeTransformUpdatedMock.Listen);
+            subject.AfterTransformUpdated.AddListener(afterTransformUpdatedMock.Listen);
+            subject.BeforePositionUpdated.AddListener(beforePositionUpdatedMock.Listen);
+            subject.AfterPositionUpdated.AddListener(afterPositionUpdatedMock.Listen);
+            subject.BeforeRotationUpdated.AddListener(beforeRotationUpdatedMock.Listen);
+            subject.AfterRotationUpdated.AddListener(afterRotationUpdatedMock.Listen);
+            subject.BeforeScaleUpdated.AddListener(beforeScaleUpdatedMock.Listen);
+            subject.AfterScaleUpdated.AddListener(afterScaleUpdatedMock.Listen);
+
+            GameObject source = new GameObject("source");
+            GameObject[] targets = new GameObject[]
+            {
+                new GameObject("target1"),
+                new GameObject("target2"),
+                new GameObject("target3")
+            };
+
+            subject.sourceComponent = source.transform;
+            subject.targetComponents = new Component[]
+            {
+                targets[0].transform, targets[1].transform, targets[2].transform
+            };
+
+            FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
+            followModifierMock.processFirstAndActiveOnly = false;
+
+            subject.follow = Data.Enum.TransformProperties.Position | Data.Enum.TransformProperties.Rotation | Data.Enum.TransformProperties.Scale;
+            subject.followModifier = followModifierMock;
+            subject.gameObject.SetActive(false);
+
+            subject.Process();
+
+            Assert.AreEqual(Vector3.zero, targets[0].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[1].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[2].transform.position);
+
+            Assert.AreEqual(Quaternion.identity, targets[0].transform.rotation);
+            Assert.AreEqual(Quaternion.identity, targets[1].transform.rotation);
+            Assert.AreEqual(Quaternion.identity, targets[2].transform.rotation);
+
+            Assert.AreEqual(Vector3.one, targets[0].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[1].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[2].transform.localScale);
+
+            Assert.IsFalse(beforeProcessedMock.Received);
+            Assert.IsFalse(afterProcessedMock.Received);
+            Assert.IsFalse(beforeTransformUpdatedMock.Received);
+            Assert.IsFalse(afterTransformUpdatedMock.Received);
+            Assert.IsFalse(beforePositionUpdatedMock.Received);
+            Assert.IsFalse(afterPositionUpdatedMock.Received);
+            Assert.IsFalse(beforeRotationUpdatedMock.Received);
+            Assert.IsFalse(afterRotationUpdatedMock.Received);
+            Assert.IsFalse(beforeScaleUpdatedMock.Received);
+            Assert.IsFalse(afterScaleUpdatedMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock beforeProcessedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterProcessedMock = new UnityEventListenerMock();
+            UnityEventListenerMock beforeTransformUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterTransformUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock beforePositionUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterPositionUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock beforeRotationUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterRotationUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock beforeScaleUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterScaleUpdatedMock = new UnityEventListenerMock();
+
+            subject.BeforeProcessed.AddListener(beforeProcessedMock.Listen);
+            subject.AfterProcessed.AddListener(afterProcessedMock.Listen);
+            subject.BeforeTransformUpdated.AddListener(beforeTransformUpdatedMock.Listen);
+            subject.AfterTransformUpdated.AddListener(afterTransformUpdatedMock.Listen);
+            subject.BeforePositionUpdated.AddListener(beforePositionUpdatedMock.Listen);
+            subject.AfterPositionUpdated.AddListener(afterPositionUpdatedMock.Listen);
+            subject.BeforeRotationUpdated.AddListener(beforeRotationUpdatedMock.Listen);
+            subject.AfterRotationUpdated.AddListener(afterRotationUpdatedMock.Listen);
+            subject.BeforeScaleUpdated.AddListener(beforeScaleUpdatedMock.Listen);
+            subject.AfterScaleUpdated.AddListener(afterScaleUpdatedMock.Listen);
+
+            GameObject source = new GameObject("source");
+            GameObject[] targets = new GameObject[]
+            {
+                new GameObject("target1"),
+                new GameObject("target2"),
+                new GameObject("target3")
+            };
+
+            subject.sourceComponent = source.transform;
+            subject.targetComponents = new Component[]
+            {
+                targets[0].transform, targets[1].transform, targets[2].transform
+            };
+
+            FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
+            followModifierMock.processFirstAndActiveOnly = false;
+
+            subject.follow = Data.Enum.TransformProperties.Position | Data.Enum.TransformProperties.Rotation | Data.Enum.TransformProperties.Scale;
+            subject.followModifier = followModifierMock;
+            subject.enabled = false;
+
+            subject.Process();
+
+            Assert.AreEqual(Vector3.zero, targets[0].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[1].transform.position);
+            Assert.AreEqual(Vector3.zero, targets[2].transform.position);
+
+            Assert.AreEqual(Quaternion.identity, targets[0].transform.rotation);
+            Assert.AreEqual(Quaternion.identity, targets[1].transform.rotation);
+            Assert.AreEqual(Quaternion.identity, targets[2].transform.rotation);
+
+            Assert.AreEqual(Vector3.one, targets[0].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[1].transform.localScale);
+            Assert.AreEqual(Vector3.one, targets[2].transform.localScale);
+
+            Assert.IsFalse(beforeProcessedMock.Received);
+            Assert.IsFalse(afterProcessedMock.Received);
+            Assert.IsFalse(beforeTransformUpdatedMock.Received);
+            Assert.IsFalse(afterTransformUpdatedMock.Received);
+            Assert.IsFalse(beforePositionUpdatedMock.Received);
+            Assert.IsFalse(afterPositionUpdatedMock.Received);
+            Assert.IsFalse(beforeRotationUpdatedMock.Received);
+            Assert.IsFalse(afterRotationUpdatedMock.Received);
+            Assert.IsFalse(beforeScaleUpdatedMock.Received);
+            Assert.IsFalse(afterScaleUpdatedMock.Received);
+        }
     }
 
     public class FollowModifierMock : FollowModifier

--- a/Tests/Editor/Tracking/SurfaceLocatorTest.cs
+++ b/Tests/Editor/Tracking/SurfaceLocatorTest.cs
@@ -48,7 +48,7 @@
             subject.Process();
 
             Assert.IsTrue(surfaceLocatedMock.Received);
-            Assert.AreEqual(subject.SurfaceData.transform, validSurface.transform);
+            Assert.AreEqual(validSurface.transform, subject.SurfaceData.transform);
         }
 
         [Test]
@@ -83,6 +83,38 @@
             subject.targetValidity = exclusions;
 
             subject.Locate();
+            Assert.IsFalse(surfaceLocatedMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock surfaceLocatedMock = new UnityEventListenerMock();
+            subject.SurfaceLocated.AddListener(surfaceLocatedMock.Listen);
+
+            validSurface.transform.position = Vector3.forward * 5f;
+
+            subject.searchOrigin = searchOrigin.transform;
+            subject.searchDirection = Vector3.forward;
+            subject.gameObject.SetActive(false);
+            subject.Process();
+
+            Assert.IsFalse(surfaceLocatedMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock surfaceLocatedMock = new UnityEventListenerMock();
+            subject.SurfaceLocated.AddListener(surfaceLocatedMock.Listen);
+
+            validSurface.transform.position = Vector3.forward * 5f;
+
+            subject.searchOrigin = searchOrigin.transform;
+            subject.searchDirection = Vector3.forward;
+            subject.enabled = false;
+            subject.Process();
+
             Assert.IsFalse(surfaceLocatedMock.Received);
         }
     }

--- a/Tests/Editor/Tracking/TransformModifyTest.cs
+++ b/Tests/Editor/Tracking/TransformModifyTest.cs
@@ -154,5 +154,67 @@
             Assert.IsTrue(beforeTransformUpdatedMock.Received);
             Assert.IsTrue(afterTransformUpdatedMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock beforeTransformUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterTransformUpdatedMock = new UnityEventListenerMock();
+            subject.BeforeTransformUpdated.AddListener(beforeTransformUpdatedMock.Listen);
+            subject.AfterTransformUpdated.AddListener(afterTransformUpdatedMock.Listen);
+
+            subject.source = sourceObject.transform;
+            subject.gameObject.SetActive(false);
+
+            subject.Modify(targetTransformData);
+
+            Assert.IsFalse(beforeTransformUpdatedMock.Received);
+            Assert.IsFalse(afterTransformUpdatedMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock beforeTransformUpdatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock afterTransformUpdatedMock = new UnityEventListenerMock();
+            subject.BeforeTransformUpdated.AddListener(beforeTransformUpdatedMock.Listen);
+            subject.AfterTransformUpdated.AddListener(afterTransformUpdatedMock.Listen);
+
+            subject.source = sourceObject.transform;
+            subject.enabled = false;
+
+            subject.Modify(targetTransformData);
+
+            Assert.IsFalse(beforeTransformUpdatedMock.Received);
+            Assert.IsFalse(afterTransformUpdatedMock.Received);
+        }
+
+        [Test]
+        public void NoModifyPositionOnInactiveGameObject()
+        {
+            targetTransformData.transform.position = Vector3.one;
+
+            subject.source = sourceObject.transform;
+            subject.applyTransformations = Data.Enum.TransformProperties.Position;
+            subject.gameObject.SetActive(false);
+
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+            subject.Modify(targetTransformData);
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+        }
+
+        [Test]
+        public void NoModifyPositionOnDisabledComponent()
+        {
+            targetTransformData.transform.position = Vector3.one;
+
+            subject.source = sourceObject.transform;
+            subject.applyTransformations = Data.Enum.TransformProperties.Position;
+            subject.enabled = false;
+
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+            subject.Modify(targetTransformData);
+            Assert.AreEqual(Vector3.zero, sourceObject.transform.position);
+        }
     }
 }

--- a/Tests/Editor/Visual/CameraColorOverlayTest.cs
+++ b/Tests/Editor/Visual/CameraColorOverlayTest.cs
@@ -59,5 +59,27 @@
             Assert.IsTrue(colorOverlayRemovedMock.Received);
             Assert.IsFalse(colorOverlayAddedMock.Received);
         }
+
+        [Test]
+        public void EventsNotEmittedOnInactiveGameObject()
+        {
+            UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
+            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.gameObject.SetActive(false);
+            subject.AddColorOverlay();
+
+            Assert.IsFalse(colorOverlayAddedMock.Received);
+        }
+
+        [Test]
+        public void EventsNotEmittedOnDisabledComponent()
+        {
+            UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
+            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.enabled = false;
+            subject.AddColorOverlay();
+
+            Assert.IsFalse(colorOverlayAddedMock.Received);
+        }
     }
 }


### PR DESCRIPTION
Events should not be emitted if the component emitting the event
is disabled or the GameObject it is on is inactive in the scene.

By default, Unity will only disable Unity loop methods if a component
is disabled or the GameObject is inactive in the scene but any
method that is manually called or called via an event link will
still execute. This may cause unexpected results if a GameObject is
inactive but linked events are still having the same effect as if
the GameObject is active.

The tests have been updated to ensure that inactive GameObjects
do not emit events or process the actions of methods being called.