### PR TITLE
fix(Pointer): update prefabs to use new follow modifier structure

### DIFF
--- a/Prefabs/Pointers/ObjectPointer.Parabolic.Solid.prefab
+++ b/Prefabs/Pointers/ObjectPointer.Parabolic.Solid.prefab
@@ -19,8 +19,9 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4622919941559180}
+  - component: {fileID: 114143654649734906}
+  - component: {fileID: 114424138616660126}
   - component: {fileID: 114787471753854276}
-  - component: {fileID: 114403715482923734}
   - component: {fileID: 114088149306012980}
   m_Layer: 0
   m_Name: FollowTarget
@@ -805,6 +806,17 @@ MonoBehaviour:
   process:
     field: {fileID: 114227604445383012}
   onlyProcessOnActiveAndEnabled: 1
+--- !u!114 &114143654649734906
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1193110632382416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b312e4fdef6b0544a894200a87b3cd5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114206215443630188
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1002,7 +1014,7 @@ MonoBehaviour:
   start: {fileID: 0}
   repeatedSegment: {fileID: 0}
   end: {fileID: 0}
---- !u!114 &114403715482923734
+--- !u!114 &114424138616660126
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -1010,9 +1022,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 1193110632382416}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e093d4d35b5601240b6061e0c9cf78d8, type: 3}
+  m_Script: {fileID: 11500000, guid: 5db8c51ac64416541922dec0c674975a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  appliedModifier: {fileID: 114143654649734906}
 --- !u!114 &114625547486584738
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1043,7 +1056,7 @@ MonoBehaviour:
   targetComponents:
   - {fileID: 0}
   follow: -1
-  followModifier: {fileID: 114403715482923734}
+  followModifier: {fileID: 114424138616660126}
   BeforeProcessed:
     m_PersistentCalls:
       m_Calls: []

--- a/Prefabs/Pointers/ObjectPointer.Straight.Solid.prefab
+++ b/Prefabs/Pointers/ObjectPointer.Straight.Solid.prefab
@@ -229,8 +229,9 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4267756628576964}
+  - component: {fileID: 114797885787679072}
+  - component: {fileID: 114125910588684792}
   - component: {fileID: 114592943992436606}
-  - component: {fileID: 114215868168741008}
   - component: {fileID: 114594640125399382}
   m_Layer: 0
   m_Name: FollowTarget
@@ -790,6 +791,18 @@ MonoBehaviour:
   start: {fileID: 0}
   repeatedSegment: {fileID: 0}
   end: {fileID: 0}
+--- !u!114 &114125910588684792
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1776246186380828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5db8c51ac64416541922dec0c674975a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  appliedModifier: {fileID: 114797885787679072}
 --- !u!114 &114197183415454534
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -892,17 +905,6 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Pointer.ObjectPointer+PointerUnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114215868168741008
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776246186380828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e093d4d35b5601240b6061e0c9cf78d8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114279091701298828
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -977,7 +979,7 @@ MonoBehaviour:
   targetComponents:
   - {fileID: 0}
   follow: -1
-  followModifier: {fileID: 114215868168741008}
+  followModifier: {fileID: 114125910588684792}
   BeforeProcessed:
     m_PersistentCalls:
       m_Calls: []
@@ -1042,3 +1044,14 @@ MonoBehaviour:
   process:
     field: {fileID: 114592943992436606}
   onlyProcessOnActiveAndEnabled: 1
+--- !u!114 &114797885787679072
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1776246186380828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b312e4fdef6b0544a894200a87b3cd5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 


### PR DESCRIPTION
The Follow Modifier structure was changed and scripts removed meaning
the Pointer prefabs were using deleted scripts. This fixes the issue
by applying the new script structure to the prefabs.