### PR TITLE
chore(events): add arguments and sender to raise methods - resolves #108

### DIFF
--- a/Scripts/Action/BooleanAction.cs
+++ b/Scripts/Action/BooleanAction.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Emits a <see cref="bool"/> value.
     /// </summary>
-    public class BooleanAction : BaseAction<bool>
+    public class BooleanAction : BaseAction<bool, BooleanAction.BooleanActionUnityEvent>
     {
         /// <summary>
         /// Defines the event with the <see cref="bool"/> state and sender <see cref="object"/>.
@@ -14,69 +14,6 @@
         [Serializable]
         public class BooleanActionUnityEvent : UnityEvent<bool, object>
         {
-        }
-
-        /// <summary>
-        /// Emitted when the action value changes into it's active state.
-        /// </summary>
-        public BooleanActionUnityEvent Activated = new BooleanActionUnityEvent();
-        /// <summary>
-        /// Emitted when the action value changes from it's previous state.
-        /// </summary>
-        public BooleanActionUnityEvent Changed = new BooleanActionUnityEvent();
-        /// <summary>
-        /// Emitted when the action value changes into it's inactive state.
-        /// </summary>
-        public BooleanActionUnityEvent Deactivated = new BooleanActionUnityEvent();
-
-        /// <inheritdoc />
-        public override void Receive(bool value, object sender = null)
-        {
-            previousValue = Value;
-            Value = value;
-            State = Value;
-            if (State)
-            {
-                OnActivated(true);
-            }
-            else
-            {
-                OnDeactivated(false);
-            }
-
-            if (HasChanged())
-            {
-                OnChanged(value);
-            }
-        }
-
-        /// <inheritdoc />
-        protected override void OnActivated(bool value)
-        {
-            State = value;
-            if (CanEmit())
-            {
-                Activated?.Invoke(value, this);
-            }
-        }
-
-        /// <inheritdoc />
-        protected override void OnChanged(bool value)
-        {
-            if (CanEmit())
-            {
-                Changed?.Invoke(value, this);
-            }
-        }
-
-        /// <inheritdoc />
-        protected override void OnDeactivated(bool value)
-        {
-            State = value;
-            if (CanEmit())
-            {
-                Deactivated?.Invoke(value, this);
-            }
         }
     }
 }

--- a/Scripts/Action/FloatAction.cs
+++ b/Scripts/Action/FloatAction.cs
@@ -2,12 +2,12 @@
 {
     using UnityEngine.Events;
     using System;
-    using VRTK.Core.Extension;
+    using VRTK.Core.Utility;
 
     /// <summary>
     /// Emits a <see cref="float"/> value.
     /// </summary>
-    public class FloatAction : BaseAction<float>
+    public class FloatAction : BaseAction<float, FloatAction.FloatActionUnityEvent>
     {
         /// <summary>
         /// Defines the event with the <see cref="float"/> value and sender <see cref="object"/>.
@@ -17,110 +17,23 @@
         {
         }
 
-        /// <summary>
-        /// Emitted when the action value changes into it's active state.
-        /// </summary>
-        public FloatActionUnityEvent Activated = new FloatActionUnityEvent();
-        /// <summary>
-        /// Emitted when the action value changes from it's previous state.
-        /// </summary>
-        public FloatActionUnityEvent Changed = new FloatActionUnityEvent();
-        /// <summary>
-        /// Emitted when the action value changes into it's inactive state.
-        /// </summary>
-        public FloatActionUnityEvent Deactivated = new FloatActionUnityEvent();
+        public float equalityTolerance = float.Epsilon;
 
-        /// <inheritdoc />
+        protected override void Awake()
+        {
+            equalityComparer = new ApproximatelyFloatComparer(equalityTolerance);
+        }
+
+        /// <inheritdoc/>
         public override void Receive(float value, object sender = null)
         {
-            previousValue = Value;
-            Value = value;
-            EmitEvents();
-            State = IsActive();
-        }
-
-        /// <inheritdoc />
-        protected override void OnActivated(float value)
-        {
-            if (CanEmit())
+            ApproximatelyFloatComparer approximatelyComparer = equalityComparer as ApproximatelyFloatComparer;
+            if (approximatelyComparer != null)
             {
-                Activated?.Invoke(value, this);
-            }
-        }
-
-        /// <inheritdoc />
-        protected override void OnChanged(float value)
-        {
-            if (CanEmit())
-            {
-                Changed?.Invoke(value, this);
-            }
-        }
-
-        /// <inheritdoc />
-        protected override void OnDeactivated(float value)
-        {
-            if (CanEmit())
-            {
-                Deactivated?.Invoke(value, this);
-            }
-        }
-
-        /// <summary>
-        /// Attempts to emit each of the events if they are should be emitted.
-        /// </summary>
-        protected virtual void EmitEvents()
-        {
-            if (Activate())
-            {
-                OnActivated(Value);
+                approximatelyComparer.tolerance = equalityTolerance;
             }
 
-            if (HasChanged())
-            {
-                OnChanged(Value);
-            }
-
-            if (Deactivate())
-            {
-                OnDeactivated(Value);
-            }
-        }
-
-        /// <summary>
-        /// Determines if the current <see cref="BaseAction{T}.Value"/> is the default float value.
-        /// </summary>
-        /// <returns><see langword="true"/> if the <see cref="BaseAction{T}.Value"/> is currently the default float value.</returns>
-        protected virtual bool DefaultValue()
-        {
-            return (Value.ApproxEquals(default(float)));
-        }
-
-        /// <summary>
-        /// Determines whether the action is transitioning it's value state.
-        /// </summary>
-        /// <returns><see langword="true"/> if the action value is changing.</returns>
-        protected virtual bool IsActive()
-        {
-            return (!DefaultValue() && HasChanged());
-        }
-
-        /// <summary>
-        /// Determines whether the action has just become active.
-        /// </summary>
-        /// <returns><see langword="true"/> if the action has just become active.</returns>
-        protected virtual bool Activate()
-        {
-            return (!State && IsActive());
-        }
-
-        /// <summary>
-        /// Determines whether the action has just become inactive.
-        /// </summary>
-        /// <returns><see langword="true"/> if the action has just become inactive.</returns>
-        protected virtual bool Deactivate()
-        {
-            return (State && (DefaultValue() || !HasChanged()));
+            base.Receive(value, sender);
         }
     }
 }

--- a/Scripts/Action/Vector2Action.cs
+++ b/Scripts/Action/Vector2Action.cs
@@ -3,11 +3,12 @@
     using UnityEngine;
     using UnityEngine.Events;
     using System;
+    using VRTK.Core.Utility;
 
     /// <summary>
     /// Emits a <see cref="Vector2"/> value.
     /// </summary>
-    public class Vector2Action : BaseAction<Vector2>
+    public class Vector2Action : BaseAction<Vector2, Vector2Action.Vector2ActionUnityEvent>
     {
         /// <summary>
         /// Defines the event with the <see cref="Vector2"/> value and sender <see cref="object"/>.
@@ -17,111 +18,23 @@
         {
         }
 
-        /// <summary>
-        /// Emitted when the action value changes into it's active state.
-        /// </summary>
-        public Vector2ActionUnityEvent Activated = new Vector2ActionUnityEvent();
-        /// <summary>
-        /// Emitted when the action value changes from it's previous state.
-        /// </summary>
-        public Vector2ActionUnityEvent Changed = new Vector2ActionUnityEvent();
-        /// <summary>
-        /// Emitted when the action value changes into it's inactive state.
-        /// </summary>
-        public Vector2ActionUnityEvent Deactivated = new Vector2ActionUnityEvent();
+        public float equalityTolerance = float.Epsilon;
 
-        /// <inheritdoc />
+        protected override void Awake()
+        {
+            equalityComparer = new ApproximatelyVector2Comparer(equalityTolerance);
+        }
+
+        /// <inheritdoc/>
         public override void Receive(Vector2 value, object sender = null)
         {
-            previousValue = Value;
-            Value = value;
-            EmitEvents();
-            State = IsActive();
-        }
-
-        /// <inheritdoc />
-        protected override void OnActivated(Vector2 value)
-        {
-            if (CanEmit())
+            ApproximatelyVector2Comparer approximatelyComparer = equalityComparer as ApproximatelyVector2Comparer;
+            if (approximatelyComparer != null)
             {
-                Activated?.Invoke(value, this);
-            }
-        }
-
-        /// <inheritdoc />
-        protected override void OnChanged(Vector2 value)
-        {
-            if (CanEmit())
-            {
-                Changed?.Invoke(value, this);
-            }
-        }
-
-        /// <inheritdoc />
-        protected override void OnDeactivated(Vector2 value)
-        {
-            if (CanEmit())
-            {
-                Deactivated?.Invoke(value, this);
-            }
-        }
-
-        /// <summary>
-        /// Attempts to emit each of the events if they are should be emitted.
-        /// </summary>
-        protected virtual void EmitEvents()
-        {
-            if (Activate())
-            {
-                OnActivated(Value);
+                approximatelyComparer.tolerance = equalityTolerance;
             }
 
-            if (HasChanged())
-            {
-                OnChanged(Value);
-            }
-
-            if (Deactivate())
-            {
-                OnDeactivated(Value);
-            }
-        }
-
-        /// <summary>
-        /// Determines if the current <see cref="BaseAction{T}.Value"/> is the default <see cref="Vector2"/> value.
-        /// </summary>
-        /// <returns><see langword="true"/> if the <see cref="BaseAction{T}.Value"/> is currently the default <see cref="Vector2"/> value.</returns>
-        protected virtual bool DefaultValue()
-        {
-            return Value.Equals(default(Vector2));
-        }
-
-        /// <summary>
-        /// Determines whether the action is transitioning it's value state.
-        /// </summary>
-        /// <returns><see langword="true"/> if the action value is changing.</returns>
-        protected virtual bool IsActive()
-        {
-            return (!DefaultValue() && HasChanged());
-        }
-
-        /// <summary>
-        /// Determines whether the action has just become active.
-        /// </summary>
-        /// <returns><see langword="true"/> if the action has just become active.</returns>
-        protected virtual bool Activate()
-        {
-            return (!State && IsActive());
-        }
-
-        /// <summary>
-        /// Determines whether the action has just become inactive.
-        /// </summary>
-        /// <returns><see langword="true"/> if the action has just become inactive.</returns>
-        protected virtual bool Deactivate()
-        {
-            return (State && (DefaultValue() || !HasChanged()));
+            base.Receive(value, sender);
         }
     }
-
 }

--- a/Scripts/Cast/ParabolicLineCast.cs
+++ b/Scripts/Cast/ParabolicLineCast.cs
@@ -152,7 +152,7 @@
                 break;
             }
 
-            OnCastResultsChanged();
+            OnCastResultsChanged(GetPayload(), this);
         }
 
         /// <summary>

--- a/Scripts/Cast/PointsCast.cs
+++ b/Scripts/Cast/PointsCast.cs
@@ -86,11 +86,11 @@
             CastPoints();
         }
 
-        protected virtual void OnCastResultsChanged()
+        protected virtual void OnCastResultsChanged(PointsCastData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                CastResultsChanged?.Invoke(GetPayload(), this);
+                CastResultsChanged?.Invoke(data, sender);
             }
         }
 

--- a/Scripts/Cast/StraightLineCast.cs
+++ b/Scripts/Cast/StraightLineCast.cs
@@ -25,7 +25,7 @@
             points[0] = transform.position;
             points[1] = (hasCollided ? hitData.point : transform.position + transform.forward * maximumLength);
 
-            OnCastResultsChanged();
+            OnCastResultsChanged(GetPayload(), this);
         }
 
         protected virtual void Awake()

--- a/Scripts/Extension/Vector2Extensions.cs
+++ b/Scripts/Extension/Vector2Extensions.cs
@@ -1,0 +1,22 @@
+﻿namespace VRTK.Core.Extension
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Extended methods for the <see cref="Vector2"/> Type.
+    /// </summary>
+    public static class Vector2Extensions
+    {
+        /// <summary>
+        /// Determines if two <see cref="Vector2"/> values are equal based on a given tolerance.
+        /// </summary>
+        /// <param name="a">The <see cref="Vector2"/> to compare against.</param>
+        /// <param name="b">The <see cref="Vector2"/> to compare with.</param>
+        /// <param name="tolerance">The tolerance in which the two <see cref="Vector2"/> values can be within to be considered equal.</param>
+        /// <returns><see langword="true"/> if the two <see cref="Vector2"/> values are considered equal.</returns>
+        public static bool ApproxEquals(this Vector2 a, Vector2 b, float tolerance = float.Epsilon)
+        {
+            return (Vector2.Distance(a, b) <= tolerance);
+        }
+    }
+}

--- a/Scripts/Extension/Vector2Extensions.cs.meta
+++ b/Scripts/Extension/Vector2Extensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3eaf8a06059fa44abff4912ef6d54ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Input/UnityAxis1DAction.cs
+++ b/Scripts/Input/UnityAxis1DAction.cs
@@ -16,10 +16,7 @@
 
         protected virtual void Update()
         {
-            Value = Input.GetAxis(axisName);
-            EmitEvents();
-            State = IsActive();
-            previousValue = Value;
+            Receive(Input.GetAxis(axisName), this);
         }
     }
 }

--- a/Scripts/Input/UnityAxis2DAction.cs
+++ b/Scripts/Input/UnityAxis2DAction.cs
@@ -21,10 +21,7 @@
 
         protected virtual void Update()
         {
-            Value = new Vector2(Input.GetAxis(xAxisName), Input.GetAxis(yAxisName));
-            EmitEvents();
-            State = IsActive();
-            previousValue = Value;
+            Receive(new Vector2(Input.GetAxis(xAxisName), Input.GetAxis(yAxisName)), this);
         }
     }
 }

--- a/Scripts/Input/UnityButtonAction.cs
+++ b/Scripts/Input/UnityButtonAction.cs
@@ -16,22 +16,7 @@
 
         protected virtual void Update()
         {
-            Value = Input.GetKey(keyCode);
-            if (Input.GetKeyDown(keyCode))
-            {
-                OnActivated(true);
-            }
-
-            if (HasChanged())
-            {
-                OnChanged(Value);
-            }
-
-            if (Input.GetKeyUp(keyCode))
-            {
-                OnDeactivated(false);
-            }
-            previousValue = Value;
+            Receive(Input.GetKey(keyCode));
         }
     }
 }

--- a/Scripts/Tracking/Follow/ObjectFollow.cs
+++ b/Scripts/Tracking/Follow/ObjectFollow.cs
@@ -85,7 +85,7 @@
         {
             if (isActiveAndEnabled)
             {
-                OnBeforeProcessed();
+                OnBeforeProcessed(null, null, this);
                 if (followModifier != null)
                 {
                     switch (followModifier.ProcessType)
@@ -98,11 +98,11 @@
                             break;
                     }
                 }
-                OnAfterProcessed();
+                OnAfterProcessed(null, null, this);
             }
         }
 
-        protected virtual void OnBeforeProcessed()
+        protected virtual void OnBeforeProcessed(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -110,7 +110,7 @@
             }
         }
 
-        protected virtual void OnAfterProcessed()
+        protected virtual void OnAfterProcessed(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -118,7 +118,7 @@
             }
         }
 
-        protected virtual void OnBeforeTransformUpdated(Transform source, Transform target)
+        protected virtual void OnBeforeTransformUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -126,7 +126,7 @@
             }
         }
 
-        protected virtual void OnAfterTransformUpdated(Transform source, Transform target)
+        protected virtual void OnAfterTransformUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -134,7 +134,7 @@
             }
         }
 
-        protected virtual void OnBeforePositionUpdated(Transform source, Transform target)
+        protected virtual void OnBeforePositionUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -142,7 +142,7 @@
             }
         }
 
-        protected virtual void OnAfterPositionUpdated(Transform source, Transform target)
+        protected virtual void OnAfterPositionUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -150,7 +150,7 @@
             }
         }
 
-        protected virtual void OnBeforeRotationUpdated(Transform source, Transform target)
+        protected virtual void OnBeforeRotationUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -158,7 +158,7 @@
             }
         }
 
-        protected virtual void OnAfterRotationUpdated(Transform source, Transform target)
+        protected virtual void OnAfterRotationUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -166,7 +166,7 @@
             }
         }
 
-        protected virtual void OnBeforeScaleUpdated(Transform source, Transform target)
+        protected virtual void OnBeforeScaleUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -174,7 +174,7 @@
             }
         }
 
-        protected virtual void OnAfterScaleUpdated(Transform source, Transform target)
+        protected virtual void OnAfterScaleUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
@@ -190,13 +190,13 @@
 
             if (followModifier != null)
             {
-                OnBeforeTransformUpdated(sourceTransform, targetTransform);
+                OnBeforeTransformUpdated(sourceTransform, targetTransform, this);
 
                 UpdateScale(sourceTransform, targetTransform);
                 UpdateRotation(sourceTransform, targetTransform);
                 UpdatePosition(sourceTransform, targetTransform);
 
-                OnAfterTransformUpdated(sourceTransform, targetTransform);
+                OnAfterTransformUpdated(sourceTransform, targetTransform, this);
             }
         }
 
@@ -209,9 +209,9 @@
         {
             if (follow.HasFlag(TransformProperties.Position))
             {
-                OnBeforePositionUpdated(sourceTransform, targetTransform);
+                OnBeforePositionUpdated(sourceTransform, targetTransform, this);
                 followModifier.UpdatePosition(sourceTransform, targetTransform);
-                OnAfterPositionUpdated(sourceTransform, targetTransform);
+                OnAfterPositionUpdated(sourceTransform, targetTransform, this);
             }
         }
 
@@ -224,9 +224,9 @@
         {
             if (follow.HasFlag(TransformProperties.Rotation))
             {
-                OnBeforeRotationUpdated(sourceTransform, targetTransform);
+                OnBeforeRotationUpdated(sourceTransform, targetTransform, this);
                 followModifier.UpdateRotation(sourceTransform, targetTransform);
-                OnAfterRotationUpdated(sourceTransform, targetTransform);
+                OnAfterRotationUpdated(sourceTransform, targetTransform, this);
             }
         }
 
@@ -239,9 +239,9 @@
         {
             if (follow.HasFlag(TransformProperties.Scale))
             {
-                OnBeforeScaleUpdated(sourceTransform, targetTransform);
+                OnBeforeScaleUpdated(sourceTransform, targetTransform, this);
                 followModifier.UpdateScale(sourceTransform, targetTransform);
-                OnAfterScaleUpdated(sourceTransform, targetTransform);
+                OnAfterScaleUpdated(sourceTransform, targetTransform, this);
             }
         }
     }

--- a/Scripts/Tracking/SurfaceLocator.cs
+++ b/Scripts/Tracking/SurfaceLocator.cs
@@ -95,15 +95,15 @@
             if (givenOrigin != null && givenOrigin.Valid && CastRay(givenOrigin.Position, searchDirection) && PositionChanged(DISTANCE_VARIANCE))
             {
                 SurfaceData.rotationOverride = givenOrigin.Rotation;
-                OnSurfaceLocated(SurfaceData);
+                OnSurfaceLocated(SurfaceData, initiator);
             }
         }
 
-        protected virtual void OnSurfaceLocated(SurfaceData e)
+        protected virtual void OnSurfaceLocated(SurfaceData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                SurfaceLocated?.Invoke(e, this);
+                SurfaceLocated?.Invoke(data, sender);
             }
         }
 

--- a/Scripts/Tracking/TransformModify.cs
+++ b/Scripts/Tracking/TransformModify.cs
@@ -54,7 +54,7 @@
         /// </summary>
         public TransformModifyUnityEvent BeforeTransformUpdated = new TransformModifyUnityEvent();
         /// <summary>
-        /// Emitted after the transformation process has occured.
+        /// Emitted after the transformation process has occurred.
         /// </summary>
         public TransformModifyUnityEvent AfterTransformUpdated = new TransformModifyUnityEvent();
 
@@ -64,7 +64,7 @@
         protected Coroutine transitionRoutine;
 
         /// <summary>
-        /// Applys the properties of the target <see cref="Transform"/> to the source <see cref="Transform"/>.
+        /// Applies the properties of the target <see cref="Transform"/> to the source <see cref="Transform"/>.
         /// </summary>
         /// <param name="target">The target <see cref="TransformData"/> to obtain the transformation properties from.</param>
         /// <param name="initiator">Tne object that initiated the modification.</param>
@@ -73,7 +73,7 @@
             if (source != null && target != null && isActiveAndEnabled)
             {
                 TransformData sourceData = new TransformData(source);
-                OnBeforeTransformUpdated(sourceData, target);
+                OnBeforeTransformUpdated(sourceData, target, initiator);
                 SetScale(sourceData, target);
                 SetPosition(sourceData, target);
                 SetRotation(sourceData, target);
@@ -86,14 +86,14 @@
             CancelTransition();
         }
 
-        protected virtual void OnBeforeTransformUpdated(TransformData givenSource, TransformData givenTarget)
+        protected virtual void OnBeforeTransformUpdated(TransformData sourceData, TransformData targetData, object sender)
         {
-            BeforeTransformUpdated?.Invoke(givenSource, givenTarget, this);
+            BeforeTransformUpdated?.Invoke(sourceData, targetData, sender);
         }
 
-        protected virtual void OnAfterTransformUpdated(TransformData givenSource, TransformData givenTarget)
+        protected virtual void OnAfterTransformUpdated(TransformData sourceData, TransformData targetData, object sender)
         {
-            AfterTransformUpdated?.Invoke(givenSource, givenTarget, this);
+            AfterTransformUpdated?.Invoke(sourceData, targetData, sender);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@
                 givenSource.transform.localScale = finalScale;
                 givenSource.transform.position = finalPosition;
                 givenSource.transform.rotation = finalRotation;
-                OnAfterTransformUpdated(givenSource, givenTarget);
+                OnAfterTransformUpdated(givenSource, givenTarget, this);
             }
             else
             {
@@ -222,7 +222,7 @@
         /// <param name="useTargetValue">Determines whether to utilize the target value.</param>
         /// <param name="targetValue">The target value to apply.</param>
         /// <param name="sourceValue">The source value to apply.</param>
-        /// <returns>Modified position which is either the given `targetValue` or given `sourceValue`.</returns>
+        /// <returns>Modified position which is either <paramref name="targetValue"/> or <paramref name="sourceValue"/>.</returns>
         protected virtual float GetModifiedPositionValue(bool useTargetValue, float targetValue, float sourceValue)
         {
             return (useTargetValue ? targetValue : sourceValue);
@@ -297,7 +297,7 @@
             affectTransform.transform.localScale = destinationScale;
             affectTransform.transform.position = destinationPosition;
             affectTransform.transform.rotation = destinationRotation;
-            OnAfterTransformUpdated(affectTransform, givenTarget);
+            OnAfterTransformUpdated(affectTransform, givenTarget, this);
         }
     }
 }

--- a/Scripts/Utility/ApproximatelyFloatComparer.cs
+++ b/Scripts/Utility/ApproximatelyFloatComparer.cs
@@ -1,0 +1,33 @@
+﻿namespace VRTK.Core.Utility
+{
+    using System.Collections.Generic;
+    using VRTK.Core.Extension;
+
+    /// <summary>
+    /// Determines if two <see cref="float"/> values are equal based on a given tolerance.
+    /// </summary>
+    public class ApproximatelyFloatComparer : IEqualityComparer<float>
+    {
+        /// <summary>
+        /// The tolerance in which the two <see cref="float"/> values can be within to be considered equal.
+        /// </summary>
+        public float tolerance;
+
+        public ApproximatelyFloatComparer(float tolerance = float.Epsilon)
+        {
+            this.tolerance = tolerance;
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(float x, float y)
+        {
+            return x.ApproxEquals(y, tolerance);
+        }
+
+        /// <inheritdoc/>
+        public int GetHashCode(float obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/Scripts/Utility/ApproximatelyFloatComparer.cs.meta
+++ b/Scripts/Utility/ApproximatelyFloatComparer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0376df4a3d4dcb84fb6965d2f990cc01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Utility/ApproximatelyVector2Comparer.cs
+++ b/Scripts/Utility/ApproximatelyVector2Comparer.cs
@@ -1,0 +1,34 @@
+﻿namespace VRTK.Core.Utility
+{
+    using UnityEngine;
+    using System.Collections.Generic;
+    using VRTK.Core.Extension;
+
+    /// <summary>
+    /// Determines if two <see cref="Vector2"/> values are equal based on a given tolerance.
+    /// </summary>
+    public class ApproximatelyVector2Comparer : IEqualityComparer<Vector2>
+    {
+        /// <summary>
+        /// The tolerance in which the two <see cref="Vector2"/> values can be within to be considered equal.
+        /// </summary>
+        public float tolerance;
+
+        public ApproximatelyVector2Comparer(float tolerance = float.Epsilon)
+        {
+            this.tolerance = tolerance;
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(Vector2 x, Vector2 y)
+        {
+            return x.ApproxEquals(y, tolerance);
+        }
+
+        /// <inheritdoc/>
+        public int GetHashCode(Vector2 obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/Scripts/Utility/ApproximatelyVector2Comparer.cs.meta
+++ b/Scripts/Utility/ApproximatelyVector2Comparer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f231091a33adf347a7840d212baf7f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Visual/CameraColorOverlay.cs
+++ b/Scripts/Visual/CameraColorOverlay.cs
@@ -54,15 +54,15 @@
         /// <summary>
         /// Emitted when an overlay <see cref="Color"/> is added.
         /// </summary>
-        public CameraColorOverlayUnityEvent ColorOverlayAdded = new CameraColorOverlayUnityEvent();
+        public CameraColorOverlayUnityEvent Added = new CameraColorOverlayUnityEvent();
         /// <summary>
         /// Emitted when an overlay <see cref="Color"/> is removed.
         /// </summary>
-        public CameraColorOverlayUnityEvent ColorOverlayRemoved = new CameraColorOverlayUnityEvent();
+        public CameraColorOverlayUnityEvent Removed = new CameraColorOverlayUnityEvent();
         /// <summary>
         /// Emitted when an overlay <see cref="Color"/> has changed from the previous render frame.
         /// </summary>
-        public CameraColorOverlayUnityEvent ColorOverlayChanged = new CameraColorOverlayUnityEvent();
+        public CameraColorOverlayUnityEvent Changed = new CameraColorOverlayUnityEvent();
 
         protected float targetDuration;
         protected Color targetColor = new Color(0f, 0f, 0f, 0f);
@@ -84,7 +84,7 @@
         public virtual void RemoveColorOverlay()
         {
             AddColorOverlay(Color.clear, removeDuration);
-            OnColorOverlayRemoved(Color.clear);
+            OnRemoved(Color.clear, this);
         }
 
         /// <summary>
@@ -107,27 +107,27 @@
             Camera.onPostRender -= PostRender;
         }
 
-        protected virtual void OnColorOverlayAdded(Color color)
+        protected virtual void OnAdded(Color color, object sender)
         {
             if (isActiveAndEnabled)
             {
-                ColorOverlayAdded?.Invoke(color, this);
+                Added?.Invoke(color, sender);
             }
         }
 
-        protected virtual void OnColorOverlayRemoved(Color color)
+        protected virtual void OnRemoved(Color color, object sender)
         {
             if (isActiveAndEnabled)
             {
-                ColorOverlayRemoved?.Invoke(color, this);
+                Removed?.Invoke(color, sender);
             }
         }
 
-        protected virtual void OnColorOverlayChanged(Color color)
+        protected virtual void OnChanged(Color color, object sender)
         {
             if (isActiveAndEnabled)
             {
-                ColorOverlayChanged?.Invoke(color, this);
+                Changed?.Invoke(color, sender);
             }
         }
 
@@ -155,7 +155,7 @@
 
                 if (newColor != Color.clear)
                 {
-                    OnColorOverlayAdded(overlayColor);
+                    OnAdded(overlayColor, this);
                 }
             }
         }
@@ -204,7 +204,7 @@
                 {
                     currentColor += deltaColor * Time.deltaTime;
                 }
-                OnColorOverlayChanged(currentColor);
+                OnChanged(currentColor, this);
             }
 
             if (currentColor.a > 0f && overlayMaterial != null)

--- a/Tests/Editor/Action/BooleanActionTest.cs
+++ b/Tests/Editor/Action/BooleanActionTest.cs
@@ -46,9 +46,9 @@
         }
 
         [Test]
-        public void DectivatedEmitted()
+        public void DeactivatedEmitted()
         {
-            subject.SetState(true);
+            subject.SetIsActivated(true);
             subject.SetValue(true);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
@@ -154,9 +154,9 @@
 
     public class BooleanActionMock : BooleanAction
     {
-        public virtual void SetState(bool value)
+        public virtual void SetIsActivated(bool value)
         {
-            State = value;
+            IsActivated = value;
         }
 
         public virtual void SetValue(bool value)

--- a/Tests/Editor/Action/CompoundAndActionTest.cs
+++ b/Tests/Editor/Action/CompoundAndActionTest.cs
@@ -29,8 +29,8 @@
             MockAction actionA = containingObject.AddComponent<MockAction>();
             MockAction actionB = containingObject.AddComponent<MockAction>();
 
-            actionA.SetState(false);
-            actionB.SetState(false);
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(false);
 
             subject.actions.Add(actionA);
             subject.actions.Add(actionB);
@@ -53,8 +53,8 @@
             Assert.IsFalse(deactivatedListenerMock.Received);
             Assert.IsFalse(changedListenerMock.Received);
 
-            actionA.SetState(true);
-            actionB.SetState(true);
+            actionA.SetIsActivated(true);
+            actionB.SetIsActivated(true);
 
             subject.ManualUpdate();
 
@@ -69,8 +69,8 @@
             MockAction actionA = containingObject.AddComponent<MockAction>();
             MockAction actionB = containingObject.AddComponent<MockAction>();
 
-            actionA.SetState(false);
-            actionB.SetState(false);
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(false);
 
             subject.actions.Add(actionA);
             subject.actions.Add(actionB);
@@ -93,8 +93,8 @@
             Assert.IsFalse(deactivatedListenerMock.Received);
             Assert.IsFalse(changedListenerMock.Received);
 
-            actionA.SetState(true);
-            actionB.SetState(false);
+            actionA.SetIsActivated(true);
+            actionB.SetIsActivated(false);
 
             subject.ManualUpdate();
 
@@ -104,16 +104,16 @@
         }
 
         [Test]
-        public void DectivatedEmitted()
+        public void DeactivatedEmitted()
         {
-            subject.SetState(true);
+            subject.SetIsActivated(true);
             subject.SetValue(true);
 
             MockAction actionA = containingObject.AddComponent<MockAction>();
             MockAction actionB = containingObject.AddComponent<MockAction>();
 
-            actionA.SetState(true);
-            actionB.SetState(true);
+            actionA.SetIsActivated(true);
+            actionB.SetIsActivated(true);
 
             subject.actions.Add(actionA);
             subject.actions.Add(actionB);
@@ -136,8 +136,8 @@
             Assert.IsFalse(deactivatedListenerMock.Received);
             Assert.IsFalse(changedListenerMock.Received);
 
-            actionA.SetState(false);
-            actionB.SetState(true);
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(true);
 
             subject.ManualUpdate();
 
@@ -152,8 +152,8 @@
             MockAction actionA = containingObject.AddComponent<MockAction>();
             MockAction actionB = containingObject.AddComponent<MockAction>();
 
-            actionA.SetState(false);
-            actionB.SetState(false);
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(false);
 
             subject.actions.Add(actionA);
             subject.actions.Add(actionB);
@@ -167,14 +167,14 @@
             subject.ManualUpdate();
             Assert.IsFalse(changedListenerMock.Received);
 
-            actionA.SetState(true);
-            actionB.SetState(true);
+            actionA.SetIsActivated(true);
+            actionB.SetIsActivated(true);
             subject.ManualUpdate();
             Assert.IsTrue(changedListenerMock.Received);
             changedListenerMock.Reset();
 
-            actionA.SetState(false);
-            actionB.SetState(true);
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(true);
             subject.ManualUpdate();
             Assert.IsTrue(changedListenerMock.Received);
             changedListenerMock.Reset();
@@ -183,20 +183,20 @@
             Assert.IsFalse(changedListenerMock.Received);
             changedListenerMock.Reset();
 
-            actionA.SetState(false);
-            actionB.SetState(false);
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(false);
             subject.ManualUpdate();
             Assert.IsFalse(changedListenerMock.Received);
             changedListenerMock.Reset();
 
-            actionA.SetState(true);
-            actionB.SetState(false);
+            actionA.SetIsActivated(true);
+            actionB.SetIsActivated(false);
             subject.ManualUpdate();
             Assert.IsFalse(changedListenerMock.Received);
             changedListenerMock.Reset();
 
-            actionA.SetState(true);
-            actionB.SetState(true);
+            actionA.SetIsActivated(true);
+            actionB.SetIsActivated(true);
             subject.ManualUpdate();
             Assert.IsTrue(changedListenerMock.Received);
         }
@@ -207,8 +207,8 @@
             MockAction actionA = containingObject.AddComponent<MockAction>();
             MockAction actionB = containingObject.AddComponent<MockAction>();
 
-            actionA.SetState(false);
-            actionB.SetState(false);
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(false);
 
             subject.actions.Add(actionA);
             subject.actions.Add(actionB);
@@ -232,8 +232,8 @@
             Assert.IsFalse(deactivatedListenerMock.Received);
             Assert.IsFalse(changedListenerMock.Received);
 
-            actionA.SetState(true);
-            actionB.SetState(true);
+            actionA.SetIsActivated(true);
+            actionB.SetIsActivated(true);
 
             subject.ManualUpdate();
 
@@ -248,8 +248,8 @@
             MockAction actionA = containingObject.AddComponent<MockAction>();
             MockAction actionB = containingObject.AddComponent<MockAction>();
 
-            actionA.SetState(false);
-            actionB.SetState(false);
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(false);
 
             subject.actions.Add(actionA);
             subject.actions.Add(actionB);
@@ -273,8 +273,8 @@
             Assert.IsFalse(deactivatedListenerMock.Received);
             Assert.IsFalse(changedListenerMock.Received);
 
-            actionA.SetState(true);
-            actionB.SetState(true);
+            actionA.SetIsActivated(true);
+            actionB.SetIsActivated(true);
 
             subject.ManualUpdate();
 
@@ -291,9 +291,9 @@
             Update();
         }
 
-        public virtual void SetState(bool value)
+        public virtual void SetIsActivated(bool value)
         {
-            State = value;
+            IsActivated = value;
         }
 
         public virtual void SetValue(bool value)
@@ -304,9 +304,9 @@
 
     public class MockAction : BaseAction
     {
-        public virtual void SetState(bool value)
+        public virtual void SetIsActivated(bool value)
         {
-            State = value;
+            IsActivated = value;
         }
     }
 }

--- a/Tests/Editor/Action/FloatActionTest.cs
+++ b/Tests/Editor/Action/FloatActionTest.cs
@@ -46,9 +46,9 @@
         }
 
         [Test]
-        public void DectivatedEmittedAtNonZero()
+        public void DeactivatedEmittedAtNonZero()
         {
-            subject.SetState(true);
+            subject.SetIsActivated(true);
             subject.SetValue(1f);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
@@ -71,9 +71,9 @@
         }
 
         [Test]
-        public void DectivatedEmittedAtZero()
+        public void DeactivatedEmittedAtZero()
         {
-            subject.SetState(true);
+            subject.SetIsActivated(true);
             subject.SetValue(1f);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
@@ -169,9 +169,9 @@
 
     public class FloatActionMock : FloatAction
     {
-        public virtual void SetState(bool value)
+        public virtual void SetIsActivated(bool value)
         {
-            State = value;
+            IsActivated = value;
         }
 
         public virtual void SetValue(float value)

--- a/Tests/Editor/Action/ToggleActionTest.cs
+++ b/Tests/Editor/Action/ToggleActionTest.cs
@@ -24,13 +24,13 @@
         }
 
         [Test]
-        public void ToggleState()
+        public void ToggleIsActivated()
         {
-            Assert.IsFalse(subject.State);
+            Assert.IsFalse(subject.IsActivated);
             subject.Receive(true, null);
-            Assert.IsTrue(subject.State);
+            Assert.IsTrue(subject.IsActivated);
             subject.Receive(true, null);
-            Assert.IsFalse(subject.State);
+            Assert.IsFalse(subject.IsActivated);
         }
 
         [Test]
@@ -56,9 +56,9 @@
         }
 
         [Test]
-        public void DectivatedEmitted()
+        public void DeactivatedEmitted()
         {
-            subject.SetState(true);
+            subject.SetIsActivated(true);
             subject.SetValue(true);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
@@ -154,9 +154,9 @@
 
     public class ToggleActionMock : ToggleAction
     {
-        public virtual void SetState(bool value)
+        public virtual void SetIsActivated(bool value)
         {
-            State = value;
+            IsActivated = value;
         }
 
         public virtual void SetValue(bool value)

--- a/Tests/Editor/Action/Vector2ActionTest.cs
+++ b/Tests/Editor/Action/Vector2ActionTest.cs
@@ -46,9 +46,9 @@
         }
 
         [Test]
-        public void DectivatedEmittedAtNonZero()
+        public void DeactivatedEmittedAtNonZero()
         {
-            subject.SetState(true);
+            subject.SetIsActivated(true);
             subject.SetValue(Vector2.one);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
@@ -71,9 +71,9 @@
         }
 
         [Test]
-        public void DectivatedEmittedAtZero()
+        public void DeactivatedEmittedAtZero()
         {
-            subject.SetState(true);
+            subject.SetIsActivated(true);
             subject.SetValue(Vector2.one);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
@@ -169,9 +169,9 @@
 
     public class Vector2ActionMock : Vector2Action
     {
-        public virtual void SetState(bool value)
+        public virtual void SetIsActivated(bool value)
         {
-            State = value;
+            IsActivated = value;
         }
 
         public virtual void SetValue(Vector2 value)

--- a/Tests/Editor/Visual/CameraColorOverlayTest.cs
+++ b/Tests/Editor/Visual/CameraColorOverlayTest.cs
@@ -27,7 +27,7 @@
         public void AddColorOverlay()
         {
             UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
-            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.Added.AddListener(colorOverlayAddedMock.Listen);
 
             subject.AddColorOverlay();
 
@@ -50,9 +50,9 @@
         public void RemoveColorOverlay()
         {
             UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
-            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.Added.AddListener(colorOverlayAddedMock.Listen);
             UnityEventListenerMock colorOverlayRemovedMock = new UnityEventListenerMock();
-            subject.ColorOverlayRemoved.AddListener(colorOverlayRemovedMock.Listen);
+            subject.Removed.AddListener(colorOverlayRemovedMock.Listen);
 
             subject.RemoveColorOverlay();
 
@@ -64,7 +64,7 @@
         public void EventsNotEmittedOnInactiveGameObject()
         {
             UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
-            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.Added.AddListener(colorOverlayAddedMock.Listen);
             subject.gameObject.SetActive(false);
             subject.AddColorOverlay();
 
@@ -75,7 +75,7 @@
         public void EventsNotEmittedOnDisabledComponent()
         {
             UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
-            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.Added.AddListener(colorOverlayAddedMock.Listen);
             subject.enabled = false;
             subject.AddColorOverlay();
 


### PR DESCRIPTION
Components that offer events should always offer methods to raise
them. The method that raises the event always needs to follow the
naming convention and additionally should always take the arguments
for the event, that is the data and sender.

This change applies the necessary changes and additionally
simplifies some of the Action implementations to reduce the number
of methods. Actions run their logic in the event-raising method now
instead of delegating it into additional methods that have no
reusability.