### PR TITLE
refactor(Structure): favour List types over arrays for public fields

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -169,6 +169,13 @@ instantiated so it is not null at runtime.
 
 `public MyEventClass MyEventAction = new MyEventClass();`
 
+Public fields that are collections should favour the
+`System.Collections.Generic.List` data type over a simple `array` as
+the `List` offers helper operators for mutating the contents of the
+list (e.g. `Add` `Remove` `Clear`). This makes it easier when accessing
+the collection via another script when the contents of the collection
+requires changing.
+
 ## Documentation
 
 All core scripts, abstractions, controls and prefabs should contain

--- a/Prefabs/Locomotion/Teleporters/Scripts/TeleporterInternalSetup.cs
+++ b/Prefabs/Locomotion/Teleporters/Scripts/TeleporterInternalSetup.cs
@@ -1,10 +1,11 @@
 ﻿namespace VRTK.Core.Prefabs.Locomotion.Teleporters
 {
     using UnityEngine;
-    using System;
+    using System.Collections.Generic;
     using VRTK.Core.Tracking;
     using VRTK.Core.Visual;
     using VRTK.Core.Data.Type;
+    using VRTK.Core.Extension;
 
     /// <summary>
     /// Provides internal settings for the teleporter prefabs.
@@ -30,17 +31,17 @@
         /// The <see cref="SurfaceLocator"/> to set aliases on.
         /// </summary>
         [Tooltip("The Surface Locators to set aliases on.")]
-        public SurfaceLocator[] surfaceLocatorAliases = Array.Empty<SurfaceLocator>();
+        public List<SurfaceLocator> surfaceLocatorAliases = new List<SurfaceLocator>();
         /// <summary>
         /// The <see cref="TransformModify"/> to set aliases on.
         /// </summary>
         [Tooltip("The Transform Modifiers to set aliases on.")]
-        public TransformModify[] transformModifierAliases = Array.Empty<TransformModify>();
+        public List<TransformModify> transformModifierAliases = new List<TransformModify>();
         /// <summary>
         /// The scene <see cref="Camera"/>s to set the <see cref="CameraColorOverlay"/>s to affect.
         /// </summary>
         [Tooltip("The scene Cameras to set the CameraColorOverlays to affect.")]
-        public CameraColorOverlay[] cameraColorOverlays = Array.Empty<CameraColorOverlay>();
+        public List<CameraColorOverlay> cameraColorOverlays = new List<CameraColorOverlay>();
 
         /// <summary>
         /// Attempts to teleport the <see cref="userSetup.playAreaAlias"/>.
@@ -62,18 +63,18 @@
 
         protected virtual void OnEnable()
         {
-            foreach (SurfaceLocator currentLocator in surfaceLocatorAliases)
+            foreach (SurfaceLocator currentLocator in surfaceLocatorAliases.EmptyIfNull())
             {
                 currentLocator.searchOrigin = userSetup.headsetAlias;
             }
 
-            foreach (TransformModify currentModifier in transformModifierAliases)
+            foreach (TransformModify currentModifier in transformModifierAliases.EmptyIfNull())
             {
                 currentModifier.source = userSetup.playAreaAlias;
                 currentModifier.offset = userSetup.headsetAlias;
             }
 
-            foreach (CameraColorOverlay currentOverlay in cameraColorOverlays)
+            foreach (CameraColorOverlay currentOverlay in cameraColorOverlays.EmptyIfNull())
             {
                 currentOverlay.validCameras = userSetup.sceneCameras;
             }

--- a/Scripts/Action/CompoundAndAction.cs
+++ b/Scripts/Action/CompoundAndAction.cs
@@ -1,7 +1,8 @@
 ﻿namespace VRTK.Core.Action
 {
     using UnityEngine;
-    using System;
+    using System.Collections.Generic;
+    using VRTK.Core.Extension;
 
     /// <summary>
     /// Emits a <see cref="bool"/> value when all given actions are in their active state.
@@ -12,7 +13,7 @@
         /// BaseActions to check the active state on.
         /// </summary>
         [Tooltip("BaseActions to check the active state on.")]
-        public BaseAction[] actions = Array.Empty<BaseAction>();
+        public List<BaseAction> actions = new List<BaseAction>();
 
         /// <summary>
         /// Not used.
@@ -26,7 +27,7 @@
         protected virtual void Update()
         {
             bool isValid = true;
-            foreach (BaseAction action in actions)
+            foreach (BaseAction action in actions.EmptyIfNull())
             {
                 if (!action.State)
                 {

--- a/Scripts/Extension/IEnumerableExtensions.cs
+++ b/Scripts/Extension/IEnumerableExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace VRTK.Core.Extension
+{
+    using System.Linq;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Extended methods for the <see cref="IEnumerable<T>"/> Type.
+    /// </summary>
+    public static class IEnumerableExtensions
+    {
+        /// <summary>
+        /// Returns an empty <see cref="IEnumerable<T>"/> if the given source is null.
+        /// </summary>
+        /// <typeparam name="T">The Type of the source.</typeparam>
+        /// <param name="source">The source <see cref="IEnumerable<T>"/></param>
+        /// <returns>The source if it is not null or an empty <see cref="IEnumerable<T>"/> if the source is null.</returns>
+        public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T> source)
+        {
+            return source ?? Enumerable.Empty<T>();
+        }
+    }
+}

--- a/Scripts/Extension/IEnumerableExtensions.cs.meta
+++ b/Scripts/Extension/IEnumerableExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eec2b8fc73685364aac726526ae8d810
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Process/MomentProcessor.cs
+++ b/Scripts/Process/MomentProcessor.cs
@@ -2,6 +2,8 @@
 {
     using UnityEngine;
     using System;
+    using System.Collections.Generic;
+    using VRTK.Core.Extension;
 
     /// <summary>
     /// Iterates through the given <see cref="MomentProcess"/> array and executes the <see cref="MomentProcess.process"/> method on the given Unity game loop moment.
@@ -48,7 +50,7 @@
         /// A collection of <see cref="MomentProcess"/> to process.
         /// </summary>
         [Tooltip("A collection of MomentProcess to process.")]
-        public MomentProcess[] processes = Array.Empty<MomentProcess>();
+        public List<MomentProcess> processes = new List<MomentProcess>();
 
         protected Moment subscribedMoment;
 
@@ -149,7 +151,7 @@
         /// </summary>
         protected virtual void Process()
         {
-            foreach (MomentProcess currentProcess in processes)
+            foreach (MomentProcess currentProcess in processes.EmptyIfNull())
             {
                 if (currentProcess != null && currentProcess.process != null)
                 {

--- a/Scripts/Process/SourceTargetProcessor.cs
+++ b/Scripts/Process/SourceTargetProcessor.cs
@@ -1,7 +1,8 @@
 ﻿namespace VRTK.Core.Process
 {
     using UnityEngine;
-    using System;
+    using System.Collections.Generic;
+    using VRTK.Core.Extension;
 
     /// <summary>
     /// An <see cref="IProcessable"/> that runs a set method on a source <see cref="Component"/> against an array of target <see cref="Component"/>s.
@@ -19,7 +20,7 @@
         /// The target <see cref="Component"/>s to apply the source to within the process.
         /// </summary>
         [Tooltip("The target Components to apply the source to within the process.")]
-        public Component[] targetComponents = Array.Empty<Component>();
+        public List<Component> targetComponents = new List<Component>();
 
         /// <summary>
         /// The <see cref="Component"/> that is currently the active target for the process.
@@ -42,7 +43,7 @@
         /// </summary>
         protected virtual void ProcessAllComponents()
         {
-            foreach (Component currentComponent in targetComponents)
+            foreach (Component currentComponent in targetComponents.EmptyIfNull())
             {
                 if (sourceComponent != null)
                 {
@@ -57,7 +58,7 @@
         protected virtual void ProcessFirstActiveComponent()
         {
             ActiveTargetComponent = null;
-            foreach (Component currentComponent in targetComponents)
+            foreach (Component currentComponent in targetComponents.EmptyIfNull())
             {
                 if (sourceComponent != null && currentComponent != null && currentComponent.gameObject.activeInHierarchy)
                 {

--- a/Scripts/Tracking/Velocity/VelocityTrackerProcessor.cs
+++ b/Scripts/Tracking/Velocity/VelocityTrackerProcessor.cs
@@ -1,18 +1,19 @@
 ﻿namespace VRTK.Core.Tracking.Velocity
 {
     using UnityEngine;
-    using System;
+    using System.Collections.Generic;
+    using VRTK.Core.Extension;
 
     /// <summary>
-    /// A proxy for reporting on velocity data on the first active <see cref="VelocityTracker"/> that is provided in the array.
+    /// A proxy for reporting on velocity data on the first active <see cref="VelocityTracker"/> that is provided in the collection.
     /// </summary>
     public class VelocityTrackerProcessor : VelocityTracker
     {
         /// <summary>
-        /// Process the first active <see cref="VelocityTracker"/> found in the array.
+        /// Process the first active <see cref="VelocityTracker"/> found in the collection.
         /// </summary>
         [Tooltip("Process the first active VelocityTracker found in the array.")]
-        public VelocityTracker[] velocityTrackers = Array.Empty<VelocityTracker>();
+        public List<VelocityTracker> velocityTrackers = new List<VelocityTracker>();
         protected VelocityTracker cachedTracker;
 
         /// <inheritdoc />
@@ -29,7 +30,7 @@
         {
             Vector3 currentVelocity = Vector3.zero;
             cachedTracker = null;
-            foreach (VelocityTracker currentTracker in velocityTrackers)
+            foreach (VelocityTracker currentTracker in velocityTrackers.EmptyIfNull())
             {
                 if (currentTracker != null && currentTracker.IsActive())
                 {
@@ -49,7 +50,7 @@
         {
             Vector3 currentAngularVelocity = Vector3.zero;
             cachedTracker = null;
-            foreach (VelocityTracker currentTracker in velocityTrackers)
+            foreach (VelocityTracker currentTracker in velocityTrackers.EmptyIfNull())
             {
                 if (currentTracker != null && currentTracker.IsActive())
                 {

--- a/Scripts/Tracking/XrDeviceRelationActivator.cs
+++ b/Scripts/Tracking/XrDeviceRelationActivator.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using UnityEngine;
     using UnityEngine.XR;
+    using VRTK.Core.Extension;
 
     /// <summary>
     /// Activates and deactivates <see cref="GameObject"/>s based on the currently loaded XR device automatically and allows to override the active <see cref="GameObject"/> manually.
@@ -33,7 +34,7 @@
         /// The relations in order they will be activated if their XR device name matches the currently loaded one.
         /// </summary>
         [Tooltip("The relations in order they will be activated if their XR device name matches the currently loaded one.")]
-        public XrDeviceRelation[] relations = Array.Empty<XrDeviceRelation>();
+        public List<XrDeviceRelation> relations = new List<XrDeviceRelation>();
 
         protected XrDeviceRelation currentRelation;
 
@@ -56,7 +57,7 @@
 
             currentRelation = relation;
 
-            IEnumerable<XrDeviceRelation> otherRelations = relations.Except(
+            IEnumerable<XrDeviceRelation> otherRelations = relations.EmptyIfNull().Except(
                 new[]
                 {
                     relation
@@ -77,7 +78,7 @@
         /// </summary>
         public virtual void Deactivate()
         {
-            foreach (GameObject relationObject in relations.Append(currentRelation).Where(relation => relation != null).SelectMany(relation => relation.gameObjects).Where(relationObject => relationObject != null))
+            foreach (GameObject relationObject in relations.EmptyIfNull().Append(currentRelation).Where(relation => relation != null).SelectMany(relation => relation.gameObjects).Where(relationObject => relationObject != null))
             {
                 relationObject.SetActive(false);
             }
@@ -87,7 +88,7 @@
 
         protected virtual void Awake()
         {
-            if (relations.Any(relation => relation.gameObjects.Any(relationObject => relationObject.activeInHierarchy)))
+            if (relations.EmptyIfNull().Any(relation => relation.gameObjects.Any(relationObject => relationObject.activeInHierarchy)))
             {
                 Debug.LogWarning($"At least one relation object is active in the scene on {nameof(Awake)} of this {nameof(XrDeviceRelationActivator)}. Having multiple relation objects active at the same time will most likely lead to issues. Make sure to deactivate them all before you play or create a build.");
             }
@@ -101,7 +102,7 @@
         protected virtual void Update()
         {
             string loadedDeviceName = GetLoadedDeviceName();
-            XrDeviceRelation desiredRelation = relations.FirstOrDefault(relation => relation.xrDeviceName == loadedDeviceName);
+            XrDeviceRelation desiredRelation = relations.EmptyIfNull().FirstOrDefault(relation => relation.xrDeviceName == loadedDeviceName);
             if (desiredRelation != null)
             {
                 Activate(desiredRelation);

--- a/Tests/Editor/Action/CompoundAndActionTest.cs
+++ b/Tests/Editor/Action/CompoundAndActionTest.cs
@@ -32,11 +32,8 @@
             actionA.SetState(false);
             actionB.SetState(false);
 
-            subject.actions = new BaseAction[]
-            {
-                actionA,
-                actionB
-            };
+            subject.actions.Add(actionA);
+            subject.actions.Add(actionB);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
             UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
@@ -75,11 +72,8 @@
             actionA.SetState(false);
             actionB.SetState(false);
 
-            subject.actions = new BaseAction[]
-            {
-                actionA,
-                actionB
-            };
+            subject.actions.Add(actionA);
+            subject.actions.Add(actionB);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
             UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
@@ -121,11 +115,8 @@
             actionA.SetState(true);
             actionB.SetState(true);
 
-            subject.actions = new BaseAction[]
-            {
-                actionA,
-                actionB
-            };
+            subject.actions.Add(actionA);
+            subject.actions.Add(actionB);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
             UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
@@ -164,11 +155,8 @@
             actionA.SetState(false);
             actionB.SetState(false);
 
-            subject.actions = new BaseAction[]
-            {
-                actionA,
-                actionB
-            };
+            subject.actions.Add(actionA);
+            subject.actions.Add(actionB);
 
             UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
 
@@ -222,11 +210,8 @@
             actionA.SetState(false);
             actionB.SetState(false);
 
-            subject.actions = new BaseAction[]
-            {
-                actionA,
-                actionB
-            };
+            subject.actions.Add(actionA);
+            subject.actions.Add(actionB);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
             UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
@@ -266,11 +251,8 @@
             actionA.SetState(false);
             actionB.SetState(false);
 
-            subject.actions = new BaseAction[]
-            {
-                actionA,
-                actionB
-            };
+            subject.actions.Add(actionA);
+            subject.actions.Add(actionB);
 
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
             UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();

--- a/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
@@ -36,10 +36,9 @@
             };
 
             subject.sourceComponent = source.transform;
-            subject.targetComponents = new Component[]
-            {
-                targets[0].transform, targets[1].transform, targets[2].transform
-            };
+            subject.targetComponents.Add(targets[0].transform);
+            subject.targetComponents.Add(targets[1].transform);
+            subject.targetComponents.Add(targets[2].transform);
 
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             followModifierMock.SetProcessType(FollowModifier.ProcessTarget.FirstActive);
@@ -66,10 +65,9 @@
             };
 
             subject.sourceComponent = source.transform;
-            subject.targetComponents = new Component[]
-            {
-                targets[0].transform, targets[1].transform, targets[2].transform
-            };
+            subject.targetComponents.Add(targets[0].transform);
+            subject.targetComponents.Add(targets[1].transform);
+            subject.targetComponents.Add(targets[2].transform);
 
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             followModifierMock.SetProcessType(FollowModifier.ProcessTarget.FirstActive);
@@ -109,10 +107,9 @@
             };
 
             subject.sourceComponent = source.transform;
-            subject.targetComponents = new Component[]
-            {
-                targets[0].transform, targets[1].transform, targets[2].transform
-            };
+            subject.targetComponents.Add(targets[0].transform);
+            subject.targetComponents.Add(targets[1].transform);
+            subject.targetComponents.Add(targets[2].transform);
 
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             followModifierMock.SetProcessType(FollowModifier.ProcessTarget.All);
@@ -158,10 +155,9 @@
             };
 
             subject.sourceComponent = source.transform;
-            subject.targetComponents = new Component[]
-            {
-                targets[0].transform, targets[1].transform, targets[2].transform
-            };
+            subject.targetComponents.Add(targets[0].transform);
+            subject.targetComponents.Add(targets[1].transform);
+            subject.targetComponents.Add(targets[2].transform);
 
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             followModifierMock.SetProcessType(FollowModifier.ProcessTarget.All);
@@ -217,10 +213,9 @@
             };
 
             subject.sourceComponent = source.transform;
-            subject.targetComponents = new Component[]
-            {
-                targets[0].transform, targets[1].transform, targets[2].transform
-            };
+            subject.targetComponents.Add(targets[0].transform);
+            subject.targetComponents.Add(targets[1].transform);
+            subject.targetComponents.Add(targets[2].transform);
 
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             followModifierMock.SetProcessType(FollowModifier.ProcessTarget.All);
@@ -278,10 +273,9 @@
             };
 
             subject.sourceComponent = source.transform;
-            subject.targetComponents = new Component[]
-            {
-                targets[0].transform, targets[1].transform, targets[2].transform
-            };
+            subject.targetComponents.Add(targets[0].transform);
+            subject.targetComponents.Add(targets[1].transform);
+            subject.targetComponents.Add(targets[2].transform);
 
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             followModifierMock.SetProcessType(FollowModifier.ProcessTarget.All);
@@ -339,10 +333,9 @@
             };
 
             subject.sourceComponent = source.transform;
-            subject.targetComponents = new Component[]
-            {
-                targets[0].transform, targets[1].transform, targets[2].transform
-            };
+            subject.targetComponents.Add(targets[0].transform);
+            subject.targetComponents.Add(targets[1].transform);
+            subject.targetComponents.Add(targets[2].transform);
 
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             followModifierMock.SetProcessType(FollowModifier.ProcessTarget.All);
@@ -408,10 +401,9 @@
             };
 
             subject.sourceComponent = source.transform;
-            subject.targetComponents = new Component[]
-            {
-                targets[0].transform, targets[1].transform, targets[2].transform
-            };
+            subject.targetComponents.Add(targets[0].transform);
+            subject.targetComponents.Add(targets[1].transform);
+            subject.targetComponents.Add(targets[2].transform);
 
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             followModifierMock.SetProcessType(FollowModifier.ProcessTarget.All);
@@ -480,10 +472,9 @@
             };
 
             subject.sourceComponent = source.transform;
-            subject.targetComponents = new Component[]
-            {
-                targets[0].transform, targets[1].transform, targets[2].transform
-            };
+            subject.targetComponents.Add(targets[0].transform);
+            subject.targetComponents.Add(targets[1].transform);
+            subject.targetComponents.Add(targets[2].transform);
 
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             followModifierMock.SetProcessType(FollowModifier.ProcessTarget.All);

--- a/Tests/Editor/Tracking/GameObjectStateMirrorTest.cs
+++ b/Tests/Editor/Tracking/GameObjectStateMirrorTest.cs
@@ -31,12 +31,9 @@
             GameObject target3 = new GameObject();
 
             subject.sourceComponent = source.GetComponent<Component>();
-            subject.targetComponents = new Component[]
-            {
-                target1.GetComponent<Component>(),
-                target2.GetComponent<Component>(),
-                target3.GetComponent<Component>()
-            };
+            subject.targetComponents.Add(target1.GetComponent<Component>());
+            subject.targetComponents.Add(target2.GetComponent<Component>());
+            subject.targetComponents.Add(target3.GetComponent<Component>());
 
             source.gameObject.SetActive(true);
 
@@ -66,12 +63,9 @@
             GameObject target3 = new GameObject();
 
             subject.sourceComponent = source.GetComponent<Component>();
-            subject.targetComponents = new Component[]
-            {
-                target1.GetComponent<Component>(),
-                target2.GetComponent<Component>(),
-                target3.GetComponent<Component>()
-            };
+            subject.targetComponents.Add(target1.GetComponent<Component>());
+            subject.targetComponents.Add(target2.GetComponent<Component>());
+            subject.targetComponents.Add(target3.GetComponent<Component>());
 
             source.gameObject.SetActive(false);
 
@@ -101,12 +95,9 @@
             GameObject target3 = new GameObject();
 
             subject.sourceComponent = source.GetComponent<Component>();
-            subject.targetComponents = new Component[]
-            {
-                target1.GetComponent<Component>(),
-                target2.GetComponent<Component>(),
-                target3.GetComponent<Component>()
-            };
+            subject.targetComponents.Add(target1.GetComponent<Component>());
+            subject.targetComponents.Add(target2.GetComponent<Component>());
+            subject.targetComponents.Add(target3.GetComponent<Component>());
 
             source.gameObject.SetActive(true);
 

--- a/Tests/Editor/Tracking/Velocity/VelocityTrackerProcessorTest.cs
+++ b/Tests/Editor/Tracking/Velocity/VelocityTrackerProcessorTest.cs
@@ -29,7 +29,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(true, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(true, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
 
             Vector3 expectedResult = new Vector3(1f, 1f, 1f);
             Vector3 unexpectedResult = new Vector3(0f, 0f, 0f);
@@ -46,7 +48,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(true, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(true, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
 
             Vector3 expectedResult = new Vector3(2f, 2f, 2f);
             Vector3 unexpectedResult = new Vector3(0f, 0f, 0f);
@@ -63,7 +67,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(false, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(true, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
 
             Vector3 expectedResult = new Vector3(3f, 3f, 3f);
             Vector3 unexpectedResult = new Vector3(0f, 0f, 0f);
@@ -80,7 +86,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(false, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(false, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
 
             Vector3 expectedResult = new Vector3(0f, 0f, 0f);
             Vector3 unexpectedResult = new Vector3(1f, 1f, 1f);
@@ -108,7 +116,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(false, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(true, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
             subject.GetVelocity();
 
             VelocityTrackerMock expectedResult = trackerThree;
@@ -126,7 +136,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(true, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(false, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
             subject.GetAngularVelocity();
 
             VelocityTrackerMock expectedResult = trackerTwo;
@@ -144,7 +156,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(true, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(true, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
 
             Vector3 expectedResult = new Vector3(1f, 1f, 1f);
             Vector3 unexpectedResult = new Vector3(0f, 0f, 0f);
@@ -161,7 +175,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(true, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(true, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
 
             Vector3 expectedResult = new Vector3(2f, 2f, 2f);
             Vector3 unexpectedResult = new Vector3(0f, 0f, 0f);
@@ -178,7 +194,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(false, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(true, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
 
             Vector3 expectedResult = new Vector3(3f, 3f, 3f);
             Vector3 unexpectedResult = new Vector3(0f, 0f, 0f);
@@ -195,7 +213,9 @@
             VelocityTrackerMock trackerTwo = MockVelocityTracker(false, new Vector3(2f, 2f, 2f), new Vector3(2f, 2f, 2f));
             VelocityTrackerMock trackerThree = MockVelocityTracker(false, new Vector3(3f, 3f, 3f), new Vector3(3f, 3f, 3f));
 
-            subject.velocityTrackers = new VelocityTracker[] { trackerOne, trackerTwo, trackerThree };
+            subject.velocityTrackers.Add(trackerOne);
+            subject.velocityTrackers.Add(trackerTwo);
+            subject.velocityTrackers.Add(trackerThree);
 
             Vector3 expectedResult = new Vector3(0f, 0f, 0f);
             Vector3 unexpectedResult = new Vector3(1f, 1f, 1f);

--- a/Tests/Editor/Tracking/XrDeviceRelationActivatorTest.cs
+++ b/Tests/Editor/Tracking/XrDeviceRelationActivatorTest.cs
@@ -40,25 +40,22 @@
             const string xrDeviceName = "XR Device";
 
             subject.xrDeviceName = xrDeviceName;
-            subject.relations = new[]
+            subject.relations.Add(new XrDeviceRelationActivator.XrDeviceRelation
             {
-                new XrDeviceRelationActivator.XrDeviceRelation
-                {
-                    xrDeviceName = xrDeviceName,
-                    gameObjects = new[]
+                xrDeviceName = xrDeviceName,
+                gameObjects = new[]
                     {
                         new GameObject()
                     }
-                },
-                new XrDeviceRelationActivator.XrDeviceRelation
-                {
-                    xrDeviceName = xrDeviceName,
-                    gameObjects = new[]
+            });
+            subject.relations.Add(new XrDeviceRelationActivator.XrDeviceRelation
+            {
+                xrDeviceName = xrDeviceName,
+                gameObjects = new[]
                     {
                         new GameObject()
                     }
-                }
-            };
+            });
 
             LogAssert.Expect(LogType.Warning, new Regex("multiple relation"));
             subject.ManualAwake();
@@ -95,11 +92,8 @@
             };
 
             subject.xrDeviceName = expectedXrDeviceName;
-            subject.relations = new[]
-            {
-                unexpectedRelation,
-                expectedRelation
-            };
+            subject.relations.Add(unexpectedRelation);
+            subject.relations.Add(expectedRelation);
 
             Assert.AreEqual(subject.CurrentRelation, null);
 
@@ -140,11 +134,8 @@
             };
 
             subject.xrDeviceName = xrDeviceName;
-            subject.relations = new[]
-            {
-                unexpectedRelation,
-                expectedRelation
-            };
+            subject.relations.Add(unexpectedRelation);
+            subject.relations.Add(expectedRelation);
 
             subject.ManualUpdate();
             subject.Activate(expectedRelation);
@@ -176,11 +167,8 @@
             };
 
             subject.xrDeviceName = expectedXrDeviceName;
-            subject.relations = new[]
-            {
-                unexpectedRelation,
-                expectedRelation
-            };
+            subject.relations.Add(unexpectedRelation);
+            subject.relations.Add(expectedRelation);
 
             subject.ManualUpdate();
 
@@ -211,10 +199,7 @@
             };
 
             subject.xrDeviceName = xrDeviceName;
-            subject.relations = new[]
-            {
-                unexpectedRelation
-            };
+            subject.relations.Add(unexpectedRelation);
 
             subject.ManualUpdate();
             subject.Activate(expectedRelation);
@@ -246,10 +231,7 @@
             };
 
             subject.xrDeviceName = expectedXrDeviceName;
-            subject.relations = new[]
-            {
-                expectedRelation
-            };
+            subject.relations.Add(expectedRelation);
 
             subject.ManualUpdate();
 
@@ -281,11 +263,8 @@
             };
 
             subject.xrDeviceName = unexpectedXrDeviceName;
-            subject.relations = new[]
-            {
-                unexpectedRelation,
-                expectedRelation
-            };
+            subject.relations.Add(unexpectedRelation);
+            subject.relations.Add(expectedRelation);
 
             subject.ManualUpdate();
             subject.xrDeviceName = expectedXrDeviceName;
@@ -309,10 +288,7 @@
             };
 
             subject.xrDeviceName = xrDeviceName;
-            subject.relations = new[]
-            {
-                relation
-            };
+            subject.relations.Add(relation);
 
             subject.ManualUpdate();
             subject.ManualOnDisable();


### PR DESCRIPTION
It is better to use a `List` type than an array for a public field as
a List comes with easier helper methods to add and remove (or clear)
items from the List. This means if someone is trying to update the List
contents via script at runtime, they don't need to mess about with an
array structure to add or remove items.

A new `IEnumerableExtensions` component has been added that adds a new
method to any `IEnumerable` type (e.g. `List`) called `EmptyIfNull`
and will return an instantiated empty `List` if the variable is null.
This will prevent null exceptions when accessing the variable in
situations like `foreach` loops.