### PR TITLE
chore(Visual): rename camera overlay events

### DIFF
--- a/Scripts/Visual/CameraColorOverlay.cs
+++ b/Scripts/Visual/CameraColorOverlay.cs
@@ -54,15 +54,15 @@
         /// <summary>
         /// Emitted when an overlay <see cref="Color"/> is added.
         /// </summary>
-        public CameraColorOverlayUnityEvent ColorOverlayAdded = new CameraColorOverlayUnityEvent();
+        public CameraColorOverlayUnityEvent Added = new CameraColorOverlayUnityEvent();
         /// <summary>
         /// Emitted when an overlay <see cref="Color"/> is removed.
         /// </summary>
-        public CameraColorOverlayUnityEvent ColorOverlayRemoved = new CameraColorOverlayUnityEvent();
+        public CameraColorOverlayUnityEvent Removed = new CameraColorOverlayUnityEvent();
         /// <summary>
         /// Emitted when an overlay <see cref="Color"/> has changed from the previous render frame.
         /// </summary>
-        public CameraColorOverlayUnityEvent ColorOverlayChanged = new CameraColorOverlayUnityEvent();
+        public CameraColorOverlayUnityEvent Changed = new CameraColorOverlayUnityEvent();
 
         protected float targetDuration;
         protected Color targetColor = new Color(0f, 0f, 0f, 0f);
@@ -84,7 +84,7 @@
         public virtual void RemoveColorOverlay()
         {
             AddColorOverlay(Color.clear, removeDuration);
-            OnColorOverlayRemoved(Color.clear);
+            OnRemoved(Color.clear);
         }
 
         /// <summary>
@@ -107,27 +107,27 @@
             Camera.onPostRender -= PostRender;
         }
 
-        protected virtual void OnColorOverlayAdded(Color color)
+        protected virtual void OnAdded(Color color)
         {
             if (isActiveAndEnabled)
             {
-                ColorOverlayAdded?.Invoke(color, this);
+                Added?.Invoke(color, this);
             }
         }
 
-        protected virtual void OnColorOverlayRemoved(Color color)
+        protected virtual void OnRemoved(Color color)
         {
             if (isActiveAndEnabled)
             {
-                ColorOverlayRemoved?.Invoke(color, this);
+                Removed?.Invoke(color, this);
             }
         }
 
-        protected virtual void OnColorOverlayChanged(Color color)
+        protected virtual void OnChanged(Color color)
         {
             if (isActiveAndEnabled)
             {
-                ColorOverlayChanged?.Invoke(color, this);
+                Changed?.Invoke(color, this);
             }
         }
 
@@ -155,7 +155,7 @@
 
                 if (newColor != Color.clear)
                 {
-                    OnColorOverlayAdded(overlayColor);
+                    OnAdded(overlayColor);
                 }
             }
         }
@@ -204,7 +204,7 @@
                 {
                     currentColor += deltaColor * Time.deltaTime;
                 }
-                OnColorOverlayChanged(currentColor);
+                OnChanged(currentColor);
             }
 
             if (currentColor.a > 0f && overlayMaterial != null)

--- a/Tests/Editor/Visual/CameraColorOverlayTest.cs
+++ b/Tests/Editor/Visual/CameraColorOverlayTest.cs
@@ -27,7 +27,7 @@
         public void AddColorOverlay()
         {
             UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
-            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.Added.AddListener(colorOverlayAddedMock.Listen);
 
             subject.AddColorOverlay();
 
@@ -50,9 +50,9 @@
         public void RemoveColorOverlay()
         {
             UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
-            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.Added.AddListener(colorOverlayAddedMock.Listen);
             UnityEventListenerMock colorOverlayRemovedMock = new UnityEventListenerMock();
-            subject.ColorOverlayRemoved.AddListener(colorOverlayRemovedMock.Listen);
+            subject.Removed.AddListener(colorOverlayRemovedMock.Listen);
 
             subject.RemoveColorOverlay();
 
@@ -64,7 +64,7 @@
         public void EventsNotEmittedOnInactiveGameObject()
         {
             UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
-            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.Added.AddListener(colorOverlayAddedMock.Listen);
             subject.gameObject.SetActive(false);
             subject.AddColorOverlay();
 
@@ -75,7 +75,7 @@
         public void EventsNotEmittedOnDisabledComponent()
         {
             UnityEventListenerMock colorOverlayAddedMock = new UnityEventListenerMock();
-            subject.ColorOverlayAdded.AddListener(colorOverlayAddedMock.Listen);
+            subject.Added.AddListener(colorOverlayAddedMock.Listen);
             subject.enabled = false;
             subject.AddColorOverlay();
 


### PR DESCRIPTION
There is no need to name an event after the type it is a member of.
This changes the `CameraColorOverlay` to use the proper event naming
convention that is used everywhere else.