### PR TITLE
chore(events): add arguments and sender to raise methods

### DIFF
--- a/Prefabs/Pointers/ObjectPointer.Parabolic.Solid.prefab
+++ b/Prefabs/Pointers/ObjectPointer.Parabolic.Solid.prefab
@@ -887,7 +887,7 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Pointer.ObjectPointer+PointsRendererUnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  BecameVisible:
+  Appeared:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114101085606245950}
@@ -903,7 +903,7 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Pointer.ObjectPointer+PointerUnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  BecameHidden:
+  Disappeared:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114101085606245950}

--- a/Prefabs/Pointers/ObjectPointer.Straight.Solid.prefab
+++ b/Prefabs/Pointers/ObjectPointer.Straight.Solid.prefab
@@ -873,7 +873,7 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Pointer.ObjectPointer+PointsRendererUnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  BecameVisible:
+  Appeared:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114279091701298828}
@@ -889,7 +889,7 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Pointer.ObjectPointer+PointerUnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  BecameHidden:
+  Disappeared:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114279091701298828}

--- a/Scripts/Action/BaseAction.cs
+++ b/Scripts/Action/BaseAction.cs
@@ -26,26 +26,29 @@
         /// Allows an action to receive the payload from another action to enable action chaining.
         /// </summary>
         /// <param name="value">The value from the action.</param>
-        /// <param name="sender">The sender of the action.</param>
-        public abstract void Receive(T value, object sender = null);
+        /// <param name="initiator">The initiator of the action.</param>
+        public abstract void Receive(T value, object initiator = null);
 
         /// <summary>
         /// Calls the appropriate Activated event.
         /// </summary>
         /// <param name="value">The value to pass to the event.</param>
-        protected abstract void OnActivated(T value);
+        /// <param name="sender">The sender of the event.</param>
+        protected abstract void OnActivated(T value, object sender);
 
         /// <summary>
         /// Calls the appropriate Changed event.
         /// </summary>
         /// <param name="value">The value to pass to the event.</param>
-        protected abstract void OnChanged(T value);
+        /// <param name="sender">The sender of the event.</param>
+        protected abstract void OnChanged(T value, object sender);
 
         /// <summary>
         /// Calls the appropriate Deactivated event.
         /// </summary>
         /// <param name="value">The value to pass to the event.</param>
-        protected abstract void OnDeactivated(T value);
+        /// <param name="sender">The sender of the event.</param>
+        protected abstract void OnDeactivated(T value, object sender);
 
         /// <summary>
         /// Determines if the action state has changed from the previous state.

--- a/Scripts/Action/BooleanAction.cs
+++ b/Scripts/Action/BooleanAction.cs
@@ -9,7 +9,7 @@
     public class BooleanAction : BaseAction<bool>
     {
         /// <summary>
-        /// Defines the event with the <see cref="bool"/> state and sender <see cref="object"/>.
+        /// Defines the event with the <see cref="bool"/> state and initiator <see cref="object"/>.
         /// </summary>
         [Serializable]
         public class BooleanActionUnityEvent : UnityEvent<bool, object>
@@ -30,52 +30,52 @@
         public BooleanActionUnityEvent Deactivated = new BooleanActionUnityEvent();
 
         /// <inheritdoc />
-        public override void Receive(bool value, object sender = null)
+        public override void Receive(bool value, object initiator = null)
         {
             previousValue = Value;
             Value = value;
             State = Value;
             if (State)
             {
-                OnActivated(true);
+                OnActivated(true, initiator);
             }
             else
             {
-                OnDeactivated(false);
+                OnDeactivated(false, initiator);
             }
 
             if (HasChanged())
             {
-                OnChanged(value);
+                OnChanged(value, initiator);
             }
         }
 
         /// <inheritdoc />
-        protected override void OnActivated(bool value)
+        protected override void OnActivated(bool value, object sender)
         {
             State = value;
             if (CanEmit())
             {
-                Activated?.Invoke(value, this);
+                Activated?.Invoke(value, sender);
             }
         }
 
         /// <inheritdoc />
-        protected override void OnChanged(bool value)
+        protected override void OnChanged(bool value, object sender)
         {
             if (CanEmit())
             {
-                Changed?.Invoke(value, this);
+                Changed?.Invoke(value, sender);
             }
         }
 
         /// <inheritdoc />
-        protected override void OnDeactivated(bool value)
+        protected override void OnDeactivated(bool value, object sender)
         {
             State = value;
             if (CanEmit())
             {
-                Deactivated?.Invoke(value, this);
+                Deactivated?.Invoke(value, sender);
             }
         }
     }

--- a/Scripts/Action/CompoundAndAction.cs
+++ b/Scripts/Action/CompoundAndAction.cs
@@ -19,8 +19,8 @@
         /// Not used.
         /// </summary>
         /// <param name="value">The value from the action.</param>
-        /// <param name="sender">The sender of the action.</param>
-        public override void Receive(bool value, object sender = null)
+        /// <param name="initiator">The initiator of the action.</param>
+        public override void Receive(bool value, object initiator = null)
         {
         }
 
@@ -38,12 +38,12 @@
 
             if (isValid && !State)
             {
-                OnActivated(true);
+                OnActivated(true, this);
             }
 
             if (!isValid && State)
             {
-                OnDeactivated(true);
+                OnDeactivated(true, this);
             }
 
             State = isValid;
@@ -52,7 +52,7 @@
 
             if (HasChanged())
             {
-                OnChanged(Value);
+                OnChanged(Value, this);
             }
         }
     }

--- a/Scripts/Action/FloatAction.cs
+++ b/Scripts/Action/FloatAction.cs
@@ -10,7 +10,7 @@
     public class FloatAction : BaseAction<float>
     {
         /// <summary>
-        /// Defines the event with the <see cref="float"/> value and sender <see cref="object"/>.
+        /// Defines the event with the <see cref="float"/> value and initiator <see cref="object"/>.
         /// </summary>
         [Serializable]
         public class FloatActionUnityEvent : UnityEvent<float, object>
@@ -31,7 +31,7 @@
         public FloatActionUnityEvent Deactivated = new FloatActionUnityEvent();
 
         /// <inheritdoc />
-        public override void Receive(float value, object sender = null)
+        public override void Receive(float value, object initiator = null)
         {
             previousValue = Value;
             Value = value;
@@ -40,29 +40,29 @@
         }
 
         /// <inheritdoc />
-        protected override void OnActivated(float value)
+        protected override void OnActivated(float value, object sender)
         {
             if (CanEmit())
             {
-                Activated?.Invoke(value, this);
+                Activated?.Invoke(value, sender);
             }
         }
 
         /// <inheritdoc />
-        protected override void OnChanged(float value)
+        protected override void OnChanged(float value, object sender)
         {
             if (CanEmit())
             {
-                Changed?.Invoke(value, this);
+                Changed?.Invoke(value, sender);
             }
         }
 
         /// <inheritdoc />
-        protected override void OnDeactivated(float value)
+        protected override void OnDeactivated(float value, object sender)
         {
             if (CanEmit())
             {
-                Deactivated?.Invoke(value, this);
+                Deactivated?.Invoke(value, sender);
             }
         }
 
@@ -73,17 +73,17 @@
         {
             if (Activate())
             {
-                OnActivated(Value);
+                OnActivated(Value, this);
             }
 
             if (HasChanged())
             {
-                OnChanged(Value);
+                OnChanged(Value, this);
             }
 
             if (Deactivate())
             {
-                OnDeactivated(Value);
+                OnDeactivated(Value, this);
             }
         }
 

--- a/Scripts/Action/ToggleAction.cs
+++ b/Scripts/Action/ToggleAction.cs
@@ -6,21 +6,21 @@
     public class ToggleAction : BooleanAction
     {
         /// <inheritdoc />
-        public override void Receive(bool value, object sender = null)
+        public override void Receive(bool value, object initiator = null)
         {
             previousValue = Value;
             Value = value;
 
             if (!State)
             {
-                OnActivated(true);
+                OnActivated(true, initiator);
             }
             else
             {
-                OnDeactivated(false);
+                OnDeactivated(false, initiator);
             }
 
-            OnChanged(value);
+            OnChanged(value, initiator);
         }
     }
 }

--- a/Scripts/Action/Vector2Action.cs
+++ b/Scripts/Action/Vector2Action.cs
@@ -31,7 +31,7 @@
         public Vector2ActionUnityEvent Deactivated = new Vector2ActionUnityEvent();
 
         /// <inheritdoc />
-        public override void Receive(Vector2 value, object sender = null)
+        public override void Receive(Vector2 value, object initiator = null)
         {
             previousValue = Value;
             Value = value;
@@ -40,29 +40,29 @@
         }
 
         /// <inheritdoc />
-        protected override void OnActivated(Vector2 value)
+        protected override void OnActivated(Vector2 value, object sender)
         {
             if (CanEmit())
             {
-                Activated?.Invoke(value, this);
+                Activated?.Invoke(value, sender);
             }
         }
 
         /// <inheritdoc />
-        protected override void OnChanged(Vector2 value)
+        protected override void OnChanged(Vector2 value, object sender)
         {
             if (CanEmit())
             {
-                Changed?.Invoke(value, this);
+                Changed?.Invoke(value, sender);
             }
         }
 
         /// <inheritdoc />
-        protected override void OnDeactivated(Vector2 value)
+        protected override void OnDeactivated(Vector2 value, object sender)
         {
             if (CanEmit())
             {
-                Deactivated?.Invoke(value, this);
+                Deactivated?.Invoke(value, sender);
             }
         }
 
@@ -73,17 +73,17 @@
         {
             if (Activate())
             {
-                OnActivated(Value);
+                OnActivated(Value, this);
             }
 
             if (HasChanged())
             {
-                OnChanged(Value);
+                OnChanged(Value, this);
             }
 
             if (Deactivate())
             {
-                OnDeactivated(Value);
+                OnDeactivated(Value, this);
             }
         }
 

--- a/Scripts/Cast/ParabolicLineCast.cs
+++ b/Scripts/Cast/ParabolicLineCast.cs
@@ -152,7 +152,7 @@
                 break;
             }
 
-            OnCastResultsChanged();
+            OnCastResultsChanged(GetPayload(), this);
         }
 
         /// <summary>

--- a/Scripts/Cast/PointsCast.cs
+++ b/Scripts/Cast/PointsCast.cs
@@ -86,11 +86,11 @@
             CastPoints();
         }
 
-        protected virtual void OnCastResultsChanged()
+        protected virtual void OnCastResultsChanged(PointsCastData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                CastResultsChanged?.Invoke(GetPayload(), this);
+                CastResultsChanged?.Invoke(data, sender);
             }
         }
 

--- a/Scripts/Cast/StraightLineCast.cs
+++ b/Scripts/Cast/StraightLineCast.cs
@@ -25,7 +25,7 @@
             points[0] = transform.position;
             points[1] = (hasCollided ? hitData.point : transform.position + transform.forward * maximumLength);
 
-            OnCastResultsChanged();
+            OnCastResultsChanged(GetPayload(), this);
         }
 
         protected virtual void Awake()

--- a/Scripts/Input/UnityButtonAction.cs
+++ b/Scripts/Input/UnityButtonAction.cs
@@ -19,17 +19,17 @@
             Value = Input.GetKey(keyCode);
             if (Input.GetKeyDown(keyCode))
             {
-                OnActivated(true);
+                OnActivated(true, this);
             }
 
             if (HasChanged())
             {
-                OnChanged(Value);
+                OnChanged(Value, this);
             }
 
             if (Input.GetKeyUp(keyCode))
             {
-                OnDeactivated(false);
+                OnDeactivated(false, this);
             }
             previousValue = Value;
         }

--- a/Scripts/Tracking/CollisionTracker.cs
+++ b/Scripts/Tracking/CollisionTracker.cs
@@ -1,8 +1,8 @@
 ﻿namespace VRTK.Core.Tracking
 {
+    using System;
     using UnityEngine;
     using UnityEngine.Events;
-    using System;
 
     /// <summary>
     /// Holds information about a tracked collision.
@@ -69,7 +69,8 @@
                     isTrigger = false,
                     collision = collision,
                     collider = collision.collider
-                });
+                },
+                this);
         }
 
         protected virtual void OnCollisionStay(Collision collision)
@@ -80,7 +81,8 @@
                     isTrigger = false,
                     collision = collision,
                     collider = collision.collider
-                });
+                },
+                this);
         }
 
         protected virtual void OnCollisionExit(Collision collision)
@@ -91,7 +93,8 @@
                     isTrigger = false,
                     collision = collision,
                     collider = collision.collider
-                });
+                },
+                this);
         }
 
         protected virtual void OnTriggerEnter(Collider collider)
@@ -102,7 +105,8 @@
                     isTrigger = true,
                     collision = null,
                     collider = collider
-                });
+                },
+                this);
         }
 
         protected virtual void OnTriggerStay(Collider collider)
@@ -113,7 +117,8 @@
                     isTrigger = true,
                     collision = null,
                     collider = collider
-                });
+                },
+                this);
         }
 
         protected virtual void OnTriggerExit(Collider collider)
@@ -124,54 +129,55 @@
                     isTrigger = true,
                     collision = null,
                     collider = collider
-                });
+                },
+                this);
         }
 
-        protected void OnCollisionEnterEvent(CollisionTrackerData data)
+        protected void OnCollisionEnterEvent(CollisionTrackerData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                CollisionEnter?.Invoke(data, this);
+                CollisionEnter?.Invoke(data, sender);
             }
         }
 
-        protected void OnCollisionStayEvent(CollisionTrackerData data)
+        protected void OnCollisionStayEvent(CollisionTrackerData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                CollisionStay?.Invoke(data, this);
+                CollisionStay?.Invoke(data, sender);
             }
         }
 
-        protected void OnCollisionExitEvent(CollisionTrackerData data)
+        protected void OnCollisionExitEvent(CollisionTrackerData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                CollisionExit?.Invoke(data, this);
+                CollisionExit?.Invoke(data, sender);
             }
         }
 
-        protected void OnTriggerEnterEvent(CollisionTrackerData data)
+        protected void OnTriggerEnterEvent(CollisionTrackerData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                TriggerEnter?.Invoke(data, this);
+                TriggerEnter?.Invoke(data, sender);
             }
         }
 
-        protected void OnTriggerStayEvent(CollisionTrackerData data)
+        protected void OnTriggerStayEvent(CollisionTrackerData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                TriggerStay?.Invoke(data, this);
+                TriggerStay?.Invoke(data, sender);
             }
         }
 
-        protected void OnTriggerExitEvent(CollisionTrackerData data)
+        protected void OnTriggerExitEvent(CollisionTrackerData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                TriggerExit?.Invoke(data, this);
+                TriggerExit?.Invoke(data, sender);
             }
         }
     }

--- a/Scripts/Tracking/Follow/ObjectFollow.cs
+++ b/Scripts/Tracking/Follow/ObjectFollow.cs
@@ -85,7 +85,7 @@
         {
             if (isActiveAndEnabled)
             {
-                OnBeforeProcessed();
+                OnBeforeProcessed(null, null, this);
                 if (followModifier != null)
                 {
                     switch (followModifier.ProcessType)
@@ -98,87 +98,87 @@
                             break;
                     }
                 }
-                OnAfterProcessed();
+                OnAfterProcessed(null, null, this);
             }
         }
 
-        protected virtual void OnBeforeProcessed()
+        protected virtual void OnBeforeProcessed(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                BeforeProcessed?.Invoke(null, null, this);
+                BeforeProcessed?.Invoke(source, target, sender);
             }
         }
 
-        protected virtual void OnAfterProcessed()
+        protected virtual void OnAfterProcessed(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                AfterProcessed?.Invoke(null, null, this);
+                AfterProcessed?.Invoke(source, target, sender);
             }
         }
 
-        protected virtual void OnBeforeTransformUpdated(Transform source, Transform target)
+        protected virtual void OnBeforeTransformUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                BeforeTransformUpdated?.Invoke(source, target, this);
+                BeforeTransformUpdated?.Invoke(source, target, sender);
             }
         }
 
-        protected virtual void OnAfterTransformUpdated(Transform source, Transform target)
+        protected virtual void OnAfterTransformUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                AfterTransformUpdated?.Invoke(source, target, this);
+                AfterTransformUpdated?.Invoke(source, target, sender);
             }
         }
 
-        protected virtual void OnBeforePositionUpdated(Transform source, Transform target)
+        protected virtual void OnBeforePositionUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                BeforePositionUpdated?.Invoke(source, target, this);
+                BeforePositionUpdated?.Invoke(source, target, sender);
             }
         }
 
-        protected virtual void OnAfterPositionUpdated(Transform source, Transform target)
+        protected virtual void OnAfterPositionUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                AfterPositionUpdated?.Invoke(source, target, this);
+                AfterPositionUpdated?.Invoke(source, target, sender);
             }
         }
 
-        protected virtual void OnBeforeRotationUpdated(Transform source, Transform target)
+        protected virtual void OnBeforeRotationUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                BeforeRotationUpdated?.Invoke(source, target, this);
+                BeforeRotationUpdated?.Invoke(source, target, sender);
             }
         }
 
-        protected virtual void OnAfterRotationUpdated(Transform source, Transform target)
+        protected virtual void OnAfterRotationUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                AfterRotationUpdated?.Invoke(source, target, this);
+                AfterRotationUpdated?.Invoke(source, target, sender);
             }
         }
 
-        protected virtual void OnBeforeScaleUpdated(Transform source, Transform target)
+        protected virtual void OnBeforeScaleUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                BeforeScaleUpdated?.Invoke(source, target, this);
+                BeforeScaleUpdated?.Invoke(source, target, sender);
             }
         }
 
-        protected virtual void OnAfterScaleUpdated(Transform source, Transform target)
+        protected virtual void OnAfterScaleUpdated(Transform source, Transform target, object sender)
         {
             if (isActiveAndEnabled)
             {
-                AfterScaleUpdated?.Invoke(source, target, this);
+                AfterScaleUpdated?.Invoke(source, target, sender);
             }
         }
 
@@ -190,13 +190,13 @@
 
             if (followModifier != null)
             {
-                OnBeforeTransformUpdated(sourceTransform, targetTransform);
+                OnBeforeTransformUpdated(sourceTransform, targetTransform, this);
 
                 UpdateScale(sourceTransform, targetTransform);
                 UpdateRotation(sourceTransform, targetTransform);
                 UpdatePosition(sourceTransform, targetTransform);
 
-                OnAfterTransformUpdated(sourceTransform, targetTransform);
+                OnAfterTransformUpdated(sourceTransform, targetTransform, this);
             }
         }
 
@@ -209,9 +209,9 @@
         {
             if (follow.HasFlag(TransformProperties.Position))
             {
-                OnBeforePositionUpdated(sourceTransform, targetTransform);
+                OnBeforePositionUpdated(sourceTransform, targetTransform, this);
                 followModifier.UpdatePosition(sourceTransform, targetTransform);
-                OnAfterPositionUpdated(sourceTransform, targetTransform);
+                OnAfterPositionUpdated(sourceTransform, targetTransform, this);
             }
         }
 
@@ -224,9 +224,9 @@
         {
             if (follow.HasFlag(TransformProperties.Rotation))
             {
-                OnBeforeRotationUpdated(sourceTransform, targetTransform);
+                OnBeforeRotationUpdated(sourceTransform, targetTransform, this);
                 followModifier.UpdateRotation(sourceTransform, targetTransform);
-                OnAfterRotationUpdated(sourceTransform, targetTransform);
+                OnAfterRotationUpdated(sourceTransform, targetTransform, this);
             }
         }
 
@@ -239,9 +239,9 @@
         {
             if (follow.HasFlag(TransformProperties.Scale))
             {
-                OnBeforeScaleUpdated(sourceTransform, targetTransform);
+                OnBeforeScaleUpdated(sourceTransform, targetTransform, this);
                 followModifier.UpdateScale(sourceTransform, targetTransform);
-                OnAfterScaleUpdated(sourceTransform, targetTransform);
+                OnAfterScaleUpdated(sourceTransform, targetTransform, this);
             }
         }
     }

--- a/Scripts/Tracking/SurfaceLocator.cs
+++ b/Scripts/Tracking/SurfaceLocator.cs
@@ -95,15 +95,15 @@
             if (givenOrigin != null && givenOrigin.Valid && CastRay(givenOrigin.Position, searchDirection) && PositionChanged(DISTANCE_VARIANCE))
             {
                 SurfaceData.rotationOverride = givenOrigin.Rotation;
-                OnSurfaceLocated(SurfaceData);
+                OnSurfaceLocated(SurfaceData, initiator);
             }
         }
 
-        protected virtual void OnSurfaceLocated(SurfaceData e)
+        protected virtual void OnSurfaceLocated(SurfaceData data, object sender)
         {
             if (isActiveAndEnabled)
             {
-                SurfaceLocated?.Invoke(e, this);
+                SurfaceLocated?.Invoke(data, sender);
             }
         }
 

--- a/Scripts/Tracking/TransformModify.cs
+++ b/Scripts/Tracking/TransformModify.cs
@@ -73,7 +73,7 @@
             if (source != null && target != null && isActiveAndEnabled)
             {
                 TransformData sourceData = new TransformData(source);
-                OnBeforeTransformUpdated(sourceData, target);
+                OnBeforeTransformUpdated(sourceData, target, initiator);
                 SetScale(sourceData, target);
                 SetPosition(sourceData, target);
                 SetRotation(sourceData, target);
@@ -86,14 +86,14 @@
             CancelTransition();
         }
 
-        protected virtual void OnBeforeTransformUpdated(TransformData givenSource, TransformData givenTarget)
+        protected virtual void OnBeforeTransformUpdated(TransformData sourceData, TransformData targetData, object sender)
         {
-            BeforeTransformUpdated?.Invoke(givenSource, givenTarget, this);
+            BeforeTransformUpdated?.Invoke(sourceData, targetData, sender);
         }
 
-        protected virtual void OnAfterTransformUpdated(TransformData givenSource, TransformData givenTarget)
+        protected virtual void OnAfterTransformUpdated(TransformData sourceData, TransformData targetData, object sender)
         {
-            AfterTransformUpdated?.Invoke(givenSource, givenTarget, this);
+            AfterTransformUpdated?.Invoke(sourceData, targetData, sender);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@
                 givenSource.transform.localScale = finalScale;
                 givenSource.transform.position = finalPosition;
                 givenSource.transform.rotation = finalRotation;
-                OnAfterTransformUpdated(givenSource, givenTarget);
+                OnAfterTransformUpdated(givenSource, givenTarget, this);
             }
             else
             {
@@ -297,7 +297,7 @@
             affectTransform.transform.localScale = destinationScale;
             affectTransform.transform.position = destinationPosition;
             affectTransform.transform.rotation = destinationRotation;
-            OnAfterTransformUpdated(affectTransform, givenTarget);
+            OnAfterTransformUpdated(affectTransform, givenTarget, this);
         }
     }
 }

--- a/Scripts/Visual/CameraColorOverlay.cs
+++ b/Scripts/Visual/CameraColorOverlay.cs
@@ -84,7 +84,7 @@
         public virtual void RemoveColorOverlay()
         {
             AddColorOverlay(Color.clear, removeDuration);
-            OnRemoved(Color.clear);
+            OnRemoved(Color.clear, this);
         }
 
         /// <summary>
@@ -107,27 +107,27 @@
             Camera.onPostRender -= PostRender;
         }
 
-        protected virtual void OnAdded(Color color)
+        protected virtual void OnAdded(Color color, object sender)
         {
             if (isActiveAndEnabled)
             {
-                Added?.Invoke(color, this);
+                Added?.Invoke(color, sender);
             }
         }
 
-        protected virtual void OnRemoved(Color color)
+        protected virtual void OnRemoved(Color color, object sender)
         {
             if (isActiveAndEnabled)
             {
-                Removed?.Invoke(color, this);
+                Removed?.Invoke(color, sender);
             }
         }
 
-        protected virtual void OnChanged(Color color)
+        protected virtual void OnChanged(Color color, object sender)
         {
             if (isActiveAndEnabled)
             {
-                Changed?.Invoke(color, this);
+                Changed?.Invoke(color, sender);
             }
         }
 
@@ -155,7 +155,7 @@
 
                 if (newColor != Color.clear)
                 {
-                    OnAdded(overlayColor);
+                    OnAdded(overlayColor, this);
                 }
             }
         }
@@ -204,7 +204,7 @@
                 {
                     currentColor += deltaColor * Time.deltaTime;
                 }
-                OnChanged(currentColor);
+                OnChanged(currentColor, this);
             }
 
             if (currentColor.a > 0f && overlayMaterial != null)


### PR DESCRIPTION
Components that offer events should always offer methods to raise
them. The method that raises the event always needs to follow the
naming convention and additionally should always take the arguments
for the event, that is the data and sender (in that order).

This change applies the necessary changes and additionally renames
the event names of `ObjectPointer` since the raise method
`OnBecameVisible` is a "message method" in Unity already. The
pointer prefabs are both updated for this name change.