### PR TITLE
refactor(Follow): reduce duplicate code in follow modifiers

### DIFF
--- a/Scripts/Tracking/Follow/Modifier/FollowModifier.cs
+++ b/Scripts/Tracking/Follow/Modifier/FollowModifier.cs
@@ -50,16 +50,66 @@
         /// </summary>
         /// <param name="source">The source to modify.</param>
         /// <param name="target">The target to utilize in the modification.</param>
-        public abstract void UpdatePosition(Transform source, Transform target);
+        public virtual void UpdatePosition(Transform source, Transform target)
+        {
+            if (isActiveAndEnabled && ValidateCache(source, target))
+            {
+                DoUpdatePosition(source, target);
+            }
+        }
+
         /// Updates the source rotation based on the target rotation.
         /// </summary>
         /// <param name="source">The source to modify.</param>
         /// <param name="target">The target to utilize in the modification.</param>
-        public abstract void UpdateRotation(Transform source, Transform target);
+        public virtual void UpdateRotation(Transform source, Transform target)
+        {
+            if (isActiveAndEnabled && ValidateCache(source, target))
+            {
+                DoUpdateRotation(source, target);
+            }
+        }
+
         /// Updates the source scale based on the target scale.
         /// </summary>
         /// <param name="source">The source to modify.</param>
         /// <param name="target">The target to utilize in the modification.</param>
-        public abstract void UpdateScale(Transform source, Transform target);
+        public virtual void UpdateScale(Transform source, Transform target)
+        {
+            if (isActiveAndEnabled && ValidateCache(source, target))
+            {
+                DoUpdateScale(source, target);
+            }
+        }
+
+        /// <summary>
+        /// Updates the source position based on the target position.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilize in the modification.</param>
+        protected abstract void DoUpdatePosition(Transform source, Transform target);
+        /// Updates the source rotation based on the target rotation.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilize in the modification.</param>
+        protected abstract void DoUpdateRotation(Transform source, Transform target);
+        /// Updates the source scale based on the target scale.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilize in the modification.</param>
+        protected abstract void DoUpdateScale(Transform source, Transform target);
+
+        /// <summary>
+        /// Caches the given source <see cref="Transform"/> and target <see cref="Transform"/> and determines if the set cache is valid.
+        /// </summary>
+        /// <param name="source">The source to modify.</param>
+        /// <param name="target">The target to utilize in the modification.</param>
+        /// <returns><see langword="true"/> if the cache contains a valid source and target.</returns>
+        protected virtual bool ValidateCache(Transform source, Transform target)
+        {
+            CachedSource = source;
+            CachedTarget = target;
+            return (CachedSource != null && CachedTarget != null);
+        }
     }
 }

--- a/Scripts/Tracking/Follow/Modifier/ModifyRigidbodyVelocity.cs
+++ b/Scripts/Tracking/Follow/Modifier/ModifyRigidbodyVelocity.cs
@@ -46,20 +46,20 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to modify.</param>
         /// <param name="target">The target <see cref="Transform"/> to utilize in the modification.</param>
-        public override void UpdatePosition(Transform source, Transform target)
+        protected override void DoUpdatePosition(Transform source, Transform target)
         {
-            CachedSource = source;
-            CachedTarget = target;
-            if (source != null && target != null && SourceRigidbody != null)
+            if (SourceRigidbody == null)
             {
-                Vector3 positionDelta = target.position - source.position;
-                Vector3 velocityTarget = positionDelta / Time.fixedDeltaTime;
-                Vector3 calculatedVelocity = Vector3.MoveTowards(SourceRigidbody.velocity, velocityTarget, maxDistanceDelta);
+                return;
+            }
 
-                if (calculatedVelocity.sqrMagnitude < velocityLimit)
-                {
-                    SourceRigidbody.velocity = calculatedVelocity;
-                }
+            Vector3 positionDelta = target.position - source.position;
+            Vector3 velocityTarget = positionDelta / Time.fixedDeltaTime;
+            Vector3 calculatedVelocity = Vector3.MoveTowards(SourceRigidbody.velocity, velocityTarget, maxDistanceDelta);
+
+            if (calculatedVelocity.sqrMagnitude < velocityLimit)
+            {
+                SourceRigidbody.velocity = calculatedVelocity;
             }
         }
 
@@ -68,38 +68,37 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to modify.</param>
         /// <param name="target">The target <see cref="Transform"/> to utilize in the modification.</param>
-        public override void UpdateRotation(Transform source, Transform target)
+        protected override void DoUpdateRotation(Transform source, Transform target)
         {
-            CachedSource = source;
-            CachedTarget = target;
-            if (source != null && target != null && SourceRigidbody != null)
+            if (SourceRigidbody == null)
             {
-                Quaternion rotationDelta = target.rotation * Quaternion.Inverse(source.rotation);
+                return;
+            }
 
-                float angle;
-                Vector3 axis;
-                rotationDelta.ToAngleAxis(out angle, out axis);
+            Quaternion rotationDelta = target.rotation * Quaternion.Inverse(source.rotation);
+            float angle;
+            Vector3 axis;
 
-                angle = ((angle > 180f) ? angle - 360f : angle);
+            rotationDelta.ToAngleAxis(out angle, out axis);
+            angle = ((angle > 180f) ? angle - 360f : angle);
 
-                if (!angle.ApproxEquals(0))
+            if (!angle.ApproxEquals(0))
+            {
+                Vector3 angularTarget = angle * axis;
+                Vector3 calculatedAngularVelocity = Vector3.MoveTowards(SourceRigidbody.angularVelocity, angularTarget, maxDistanceDelta);
+                if (angularVelocityLimit == float.PositiveInfinity || calculatedAngularVelocity.sqrMagnitude < angularVelocityLimit)
                 {
-                    Vector3 angularTarget = angle * axis;
-                    Vector3 calculatedAngularVelocity = Vector3.MoveTowards(SourceRigidbody.angularVelocity, angularTarget, maxDistanceDelta);
-                    if (angularVelocityLimit == float.PositiveInfinity || calculatedAngularVelocity.sqrMagnitude < angularVelocityLimit)
-                    {
-                        SourceRigidbody.angularVelocity = calculatedAngularVelocity;
-                    }
+                    SourceRigidbody.angularVelocity = calculatedAngularVelocity;
                 }
             }
         }
 
         /// <summary>
-        /// Does not perform any modification
+        /// Does not perform any modification.
         /// </summary>
         /// <param name="source">Unused.</param>
         /// <param name="target">Unused.</param>
-        public override void UpdateScale(Transform source, Transform target)
+        protected override void DoUpdateScale(Transform source, Transform target)
         {
         }
     }

--- a/Scripts/Tracking/Follow/Modifier/ModifyTransform.cs
+++ b/Scripts/Tracking/Follow/Modifier/ModifyTransform.cs
@@ -12,14 +12,9 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to modify.</param>
         /// <param name="target">The target <see cref="Transform"/> to utilize in the modification.</param>
-        public override void UpdatePosition(Transform source, Transform target)
+        protected override void DoUpdatePosition(Transform source, Transform target)
         {
-            CachedSource = source;
-            CachedTarget = target;
-            if (source != null && target != null)
-            {
-                source.position = target.position;
-            }
+            source.position = target.position;
         }
 
         /// <summary>
@@ -27,14 +22,9 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to modify.</param>
         /// <param name="target">The target <see cref="Transform"/> to utilize in the modification.</param>
-        public override void UpdateRotation(Transform source, Transform target)
+        protected override void DoUpdateRotation(Transform source, Transform target)
         {
-            CachedSource = source;
-            CachedTarget = target;
-            if (source != null && target != null)
-            {
-                source.rotation = target.rotation;
-            }
+            source.rotation = target.rotation;
         }
 
         /// <summary>
@@ -42,14 +32,9 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to modify.</param>
         /// <param name="target">The target <see cref="Transform"/> to utilize in the modification.</param>
-        public override void UpdateScale(Transform source, Transform target)
+        protected override void DoUpdateScale(Transform source, Transform target)
         {
-            CachedSource = source;
-            CachedTarget = target;
-            if (source != null && target != null)
-            {
-                source.localScale = target.localScale;
-            }
+            source.localScale = target.localScale;
         }
     }
 }

--- a/Scripts/Tracking/Follow/Modifier/SourceFollowActiveTarget.cs
+++ b/Scripts/Tracking/Follow/Modifier/SourceFollowActiveTarget.cs
@@ -18,16 +18,12 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to modify.</param>
         /// <param name="target">The target <see cref="Transform"/> to utilize in the modification.</param>
-        public override void UpdatePosition(Transform source, Transform target)
+        protected override void DoUpdatePosition(Transform source, Transform target)
         {
-            if (!isActiveAndEnabled || appliedModifier == null)
+            if (appliedModifier != null)
             {
-                return;
+                appliedModifier.UpdatePosition(source, target);
             }
-
-            appliedModifier.UpdatePosition(source, target);
-            CachedSource = appliedModifier.CachedSource;
-            CachedTarget = appliedModifier.CachedTarget;
         }
 
         /// <summary>
@@ -35,16 +31,12 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to modify.</param>
         /// <param name="target">The target <see cref="Transform"/> to utilize in the modification.</param>
-        public override void UpdateRotation(Transform source, Transform target)
+        protected override void DoUpdateRotation(Transform source, Transform target)
         {
-            if (!isActiveAndEnabled || appliedModifier == null)
+            if (appliedModifier != null)
             {
-                return;
+                appliedModifier.UpdateRotation(source, target);
             }
-
-            appliedModifier.UpdateRotation(source, target);
-            CachedSource = appliedModifier.CachedSource;
-            CachedTarget = appliedModifier.CachedTarget;
         }
 
         /// <summary>
@@ -52,16 +44,12 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to modify.</param>
         /// <param name="target">The target <see cref="Transform"/> to utilize in the modification.</param>
-        public override void UpdateScale(Transform source, Transform target)
+        protected override void DoUpdateScale(Transform source, Transform target)
         {
-            if (!isActiveAndEnabled || appliedModifier == null)
+            if (appliedModifier != null)
             {
-                return;
+                appliedModifier.UpdateScale(source, target);
             }
-
-            appliedModifier.UpdateScale(source, target);
-            CachedSource = appliedModifier.CachedSource;
-            CachedTarget = appliedModifier.CachedTarget;
         }
 
         protected virtual void Awake()

--- a/Scripts/Tracking/Follow/Modifier/TargetsFollowSource.cs
+++ b/Scripts/Tracking/Follow/Modifier/TargetsFollowSource.cs
@@ -18,16 +18,12 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to utilize in the modification.</param>
         /// <param name="target">The target <see cref="Transform"/> to modify.</param>
-        public override void UpdatePosition(Transform source, Transform target)
+        protected override void DoUpdatePosition(Transform source, Transform target)
         {
-            if (!isActiveAndEnabled || appliedModifier == null)
+            if (appliedModifier != null)
             {
-                return;
+                appliedModifier.UpdatePosition(target, source);
             }
-
-            appliedModifier.UpdatePosition(target, source);
-            CachedSource = appliedModifier.CachedSource;
-            CachedTarget = appliedModifier.CachedTarget;
         }
 
         /// <summary>
@@ -35,16 +31,12 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to utilize in the modification.</param>
         /// <param name="target">The target <see cref="Transform"/> to modify.</param>
-        public override void UpdateRotation(Transform source, Transform target)
+        protected override void DoUpdateRotation(Transform source, Transform target)
         {
-            if (!isActiveAndEnabled || appliedModifier == null)
+            if (appliedModifier != null)
             {
-                return;
+                appliedModifier.UpdateRotation(target, source);
             }
-
-            appliedModifier.UpdateRotation(target, source);
-            CachedSource = appliedModifier.CachedSource;
-            CachedTarget = appliedModifier.CachedTarget;
         }
 
         /// <summary>
@@ -52,16 +44,12 @@
         /// </summary>
         /// <param name="source">The source <see cref="Transform"/> to utilize in the modification.</param>
         /// <param name="target">The target <see cref="Transform"/> to modify.</param>
-        public override void UpdateScale(Transform source, Transform target)
+        protected override void DoUpdateScale(Transform source, Transform target)
         {
-            if (!isActiveAndEnabled || appliedModifier == null)
+            if (appliedModifier != null)
             {
-                return;
+                appliedModifier.UpdateScale(target, source);
             }
-
-            appliedModifier.UpdateScale(target, source);
-            CachedSource = appliedModifier.CachedSource;
-            CachedTarget = appliedModifier.CachedTarget;
         }
 
         protected virtual void Awake()

--- a/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectFollowTest.cs
@@ -517,17 +517,17 @@
             ProcessType = type;
         }
 
-        public override void UpdatePosition(Transform source, Transform target)
+        protected override void DoUpdatePosition(Transform source, Transform target)
         {
             target.position = Vector3.one;
         }
 
-        public override void UpdateRotation(Transform source, Transform target)
+        protected override void DoUpdateRotation(Transform source, Transform target)
         {
             target.rotation = new Quaternion(1f, 0f, 0f, 0f);
         }
 
-        public override void UpdateScale(Transform source, Transform target)
+        protected override void DoUpdateScale(Transform source, Transform target)
         {
             target.localScale = new Vector3(2f, 2f, 2f);
         }


### PR DESCRIPTION
There were a number of places where the same logic in different
FollowModifier components was being repeated, such as the caching
of the transforms.

This has all now been moved into the base class so the extended
classes can focus on exactly what they're meant to do and not worry
about the caching.