### PR TITLE
fix(events): ensure digested event data is not mutated

### DIFF
--- a/Scripts/Cast/PointsCast.cs
+++ b/Scripts/Cast/PointsCast.cs
@@ -27,11 +27,21 @@
             /// </summary>
             public IReadOnlyList<Vector3> points;
 
+            public EventData Set(EventData source)
+            {
+                return Set(source.targetHit, source.points);
+            }
+
             public EventData Set(RaycastHit? targetHit, IReadOnlyList<Vector3> points)
             {
                 this.targetHit = targetHit;
                 this.points = points;
                 return this;
+            }
+
+            public void Clear()
+            {
+                Set(default(RaycastHit?), default(IReadOnlyList<Vector3>));
             }
         }
 

--- a/Scripts/Pointer/ObjectPointer.cs
+++ b/Scripts/Pointer/ObjectPointer.cs
@@ -37,6 +37,11 @@
             /// </summary>
             public PointsCast.EventData pointsCastData;
 
+            public EventData Set(EventData source)
+            {
+                return Set(source.isActive, source.isHovering, source.hoverDuration, source.pointsCastData);
+            }
+
             public EventData Set(bool isActive, bool isHovering, float hoverDuration, PointsCast.EventData pointsCastData)
             {
                 this.isActive = isActive;
@@ -44,6 +49,11 @@
                 this.hoverDuration = hoverDuration;
                 this.pointsCastData = pointsCastData;
                 return this;
+            }
+
+            public void Clear()
+            {
+                Set(default(bool), default(bool), default(float), default(PointsCast.EventData));
             }
         }
 
@@ -237,8 +247,8 @@
             }
         }
 
-        protected PointsCast.EventData activePointsCastData;
-        protected PointsCast.EventData previousPointsCastData;
+        protected PointsCast.EventData activePointsCastData = new PointsCast.EventData();
+        protected PointsCast.EventData previousPointsCastData = new PointsCast.EventData();
         protected bool? previousVisibility;
         protected EventData eventData = new EventData();
         PointsRenderer.PointsData pointsData = new PointsRenderer.PointsData();
@@ -293,7 +303,7 @@
 
             if (IsVisible)
             {
-                previousPointsCastData = activePointsCastData;
+                previousPointsCastData.Set(activePointsCastData);
                 if (data.targetHit != null)
                 {
                     Transform targetTransform = data.targetHit.Value.transform;
@@ -312,12 +322,12 @@
                     TryEmitExit(previousPointsCastData);
                 }
 
-                activePointsCastData = data;
+                activePointsCastData.Set(data);
             }
             else
             {
-                activePointsCastData = null;
-                previousPointsCastData = null;
+                activePointsCastData.Clear();
+                previousPointsCastData.Clear();
             }
 
             UpdateRenderData();
@@ -350,7 +360,7 @@
         /// </summary>
         protected virtual void UpdateRenderData()
         {
-            pointsData.points = activePointsCastData?.points ?? Array.Empty<Vector3>();
+            pointsData.points = (activePointsCastData.points ?? Array.Empty<Vector3>());
             pointsData.start = GetElementRepresentation(origin);
             pointsData.repeatedSegment = GetElementRepresentation(repeatedSegment);
             pointsData.end = GetElementRepresentation(destination);
@@ -416,8 +426,8 @@
             TryEmitExit(previousPointsCastData);
             Deactivated?.Invoke(HoverTarget);
             ActivationState = false;
-            activePointsCastData = null;
-            previousPointsCastData = null;
+            activePointsCastData.Clear();
+            previousPointsCastData.Clear();
             UpdateRenderData();
         }
 
@@ -427,7 +437,7 @@
         /// <param name="data">The current points cast data.</param>
         protected virtual void TryEmitExit(PointsCast.EventData data)
         {
-            if (activePointsCastData?.targetHit?.transform != null)
+            if (activePointsCastData.targetHit?.transform != null)
             {
                 Exited?.Invoke(GetEventData(data));
                 IsHovering = false;
@@ -464,7 +474,7 @@
         /// <returns>A <see cref="GameObject"/> to represent <paramref name="element"/>.</returns>
         protected virtual GameObject GetElementRepresentation(Element element)
         {
-            bool isValid = (activePointsCastData?.targetHit != null);
+            bool isValid = (activePointsCastData.targetHit != null);
 
             switch (element.visibility)
             {

--- a/Scripts/Tracking/CollisionTracker.cs
+++ b/Scripts/Tracking/CollisionTracker.cs
@@ -28,12 +28,22 @@
             /// </summary>
             public Collider collider;
 
+            public EventData Set(EventData source)
+            {
+                return Set(source.isTrigger, source.collision, source.collider);
+            }
+
             public EventData Set(bool isTrigger, Collision collision, Collider collider)
             {
                 this.isTrigger = isTrigger;
                 this.collision = collision;
                 this.collider = collider;
                 return this;
+            }
+
+            public void Clear()
+            {
+                Set(default(bool), default(Collision), default(Collider));
             }
         }
 

--- a/Scripts/Tracking/Follow/ObjectFollow.cs
+++ b/Scripts/Tracking/Follow/ObjectFollow.cs
@@ -30,11 +30,21 @@
             /// </summary>
             public Transform target;
 
+            public EventData Set(EventData source)
+            {
+                return Set(source.source, source.target);
+            }
+
             public EventData Set(Transform source, Transform target)
             {
                 this.source = source;
                 this.target = target;
                 return this;
+            }
+
+            public void Clear()
+            {
+                Set(default(Transform), default(Transform));
             }
         }
 

--- a/Scripts/Tracking/TransformModify.cs
+++ b/Scripts/Tracking/TransformModify.cs
@@ -29,11 +29,21 @@
             /// </summary>
             public TransformData target;
 
+            public EventData Set(EventData source)
+            {
+                return Set(source.source, source.target);
+            }
+
             public EventData Set(TransformData source, TransformData target)
             {
                 this.source = source;
                 this.target = target;
                 return this;
+            }
+
+            public void Clear()
+            {
+                Set(default(TransformData), default(TransformData));
             }
         }
 
@@ -184,8 +194,8 @@
         {
             if (!applyTransformations.HasFlag(TransformProperties.Position) && offset != null)
             {
-                target.transform.position = GetModifiedPosition(givenSource);
-                finalPosition = CalculatePosition(givenSource, target.Position, target.Rotation, finalScale);
+                Vector3 updatedPosition = GetModifiedPosition(givenSource);
+                finalPosition = CalculatePosition(givenSource, updatedPosition, target.Rotation, finalScale);
             }
         }
 

--- a/Scripts/Visual/CameraColorOverlay.cs
+++ b/Scripts/Visual/CameraColorOverlay.cs
@@ -23,10 +23,20 @@
             /// </summary>
             public Color color;
 
+            public EventData Set(EventData source)
+            {
+                return Set(source.color);
+            }
+
             public EventData Set(Color color)
             {
                 this.color = color;
                 return this;
+            }
+
+            public void Clear()
+            {
+                Set(default(Color));
             }
         }
 


### PR DESCRIPTION
As event data payloads are the same instance that is just mutated each
time the event is emitted, this means any listener that digests the
event should not attempt to mutate the event data otherwise it will
change the original reference.

Therefore, a new EventData payload should be instantiated and be a
new instance to prevent overriding the original data.

This is achieved by a new `Set` method that accepts the `EventData`
as the parameter and a new `Clear` method that resets the data
back to the default values.