### PR TITLE
refactor(Velocity): move common calls into base class

### DIFF
--- a/Scripts/Tracking/Velocity/VelocityEstimator.cs
+++ b/Scripts/Tracking/Velocity/VelocityEstimator.cs
@@ -42,18 +42,6 @@
             return (isActiveAndEnabled && source != null && source.gameObject.activeInHierarchy);
         }
 
-        /// <inheritdoc />
-        public override Vector3 GetVelocity()
-        {
-            return GetEstimate(velocitySamples);
-        }
-
-        /// <inheritdoc />
-        public override Vector3 GetAngularVelocity()
-        {
-            return GetEstimate(angularVelocitySamples);
-        }
-
         /// <summary>
         /// Manually enables the collecting of samples for the estimation process.
         /// </summary>
@@ -85,6 +73,11 @@
         /// <returns>Acceleration of the <see cref="source"/>.</returns>
         public virtual Vector3 GetAcceleration()
         {
+            if (!IsActive())
+            {
+                return Vector3.zero;
+            }
+
             Vector3 average = Vector3.zero;
             for (int i = 2 + currentSampleCount - velocitySamples.Length; i < currentSampleCount; i++)
             {
@@ -114,6 +107,18 @@
         protected virtual void LateUpdate()
         {
             ProcessEstimation();
+        }
+
+        /// <inheritdoc />
+        protected override Vector3 DoGetVelocity()
+        {
+            return GetEstimate(velocitySamples);
+        }
+
+        /// <inheritdoc />
+        protected override Vector3 DoGetAngularVelocity()
+        {
+            return GetEstimate(angularVelocitySamples);
         }
 
         /// <summary>

--- a/Scripts/Tracking/Velocity/VelocityTracker.cs
+++ b/Scripts/Tracking/Velocity/VelocityTracker.cs
@@ -12,15 +12,34 @@
         /// </summary>
         /// <returns><see langword="true"/> if the <see cref="Component"/> is considered active.</returns>
         public abstract bool IsActive();
+
         /// <summary>
         /// Gets the current velocity of the <see cref="source"/>.
         /// </summary>
         /// <returns>The current velocity of the <see cref="source"/></returns>
-        public abstract Vector3 GetVelocity();
+        public virtual Vector3 GetVelocity()
+        {
+            return (IsActive() ? DoGetVelocity() : Vector3.zero);
+        }
+
         /// <summary>
         /// Gets the current angular velocity of the <see cref="source"/>.
         /// </summary>
         /// <returns>The current angular velocity of the <see cref="source"/></returns>
-        public abstract Vector3 GetAngularVelocity();
+        public virtual Vector3 GetAngularVelocity()
+        {
+            return (IsActive() ? DoGetAngularVelocity() : Vector3.zero);
+        }
+
+        /// <summary>
+        /// Gets the current velocity of the <see cref="source"/>.
+        /// </summary>
+        /// <returns>The current velocity of the <see cref="source"/></returns>
+        protected abstract Vector3 DoGetVelocity();
+        /// <summary>
+        /// Gets the current angular velocity of the <see cref="source"/>.
+        /// </summary>
+        /// <returns>The current angular velocity of the <see cref="source"/></returns>
+        protected abstract Vector3 DoGetAngularVelocity();
     }
 }

--- a/Scripts/Tracking/Velocity/VelocityTrackerProcessor.cs
+++ b/Scripts/Tracking/Velocity/VelocityTrackerProcessor.cs
@@ -23,10 +23,19 @@
         }
 
         /// <summary>
+        /// The current active <see cref="VelocityTracker"/> that is reporting velocities.
+        /// </summary>
+        /// <returns>The current active <see cref="VelocityTracker"/>.</returns>
+        public virtual VelocityTracker GetActiveVelocityTracker()
+        {
+            return (cachedTracker != null && cachedTracker.IsActive() ? cachedTracker : null);
+        }
+
+        /// <summary>
         /// The reported velocity on the first active <see cref="VelocityTracker"/>.
         /// </summary>
         /// <returns>The current velocity.</returns>
-        public override Vector3 GetVelocity()
+        protected override Vector3 DoGetVelocity()
         {
             Vector3 currentVelocity = Vector3.zero;
             cachedTracker = null;
@@ -46,7 +55,7 @@
         /// The reported angular velocity on the first active <see cref="VelocityTracker"/>.
         /// </summary>
         /// <returns>The current angular velocity.</returns>
-        public override Vector3 GetAngularVelocity()
+        protected override Vector3 DoGetAngularVelocity()
         {
             Vector3 currentAngularVelocity = Vector3.zero;
             cachedTracker = null;
@@ -60,15 +69,6 @@
                 }
             }
             return currentAngularVelocity;
-        }
-
-        /// <summary>
-        /// The current active <see cref="VelocityTracker"/> that is reporting velocities.
-        /// </summary>
-        /// <returns>The current active <see cref="VelocityTracker"/>.</returns>
-        public virtual VelocityTracker GetActiveVelocityTracker()
-        {
-            return (cachedTracker != null && cachedTracker.IsActive() ? cachedTracker : null);
         }
     }
 }

--- a/Tests/Editor/Tracking/Velocity/VelocityTrackerProcessorTest.cs
+++ b/Tests/Editor/Tracking/Velocity/VelocityTrackerProcessorTest.cs
@@ -263,12 +263,12 @@
             return mockActive;
         }
 
-        public override Vector3 GetVelocity()
+        protected override Vector3 DoGetVelocity()
         {
             return mockVelocity;
         }
 
-        public override Vector3 GetAngularVelocity()
+        protected override Vector3 DoGetAngularVelocity()
         {
             return mockAngularVelocity;
         }


### PR DESCRIPTION
The Velocity Estimator concrete classes always made a call to
`IsActive` but this logic is consistent across all sub classes so
it has now been moved into the base class and the public methods
are no longer abstract, instead the implementation is a protected
method that is abstract and requires overriding.