### PR TITLE
fix(Tracking): update enum attribute to UnityFlags in collision tracker

### DIFF
--- a/Scripts/Tracking/CollisionTracker.cs
+++ b/Scripts/Tracking/CollisionTracker.cs
@@ -75,7 +75,7 @@
         /// <summary>
         /// The types of collisions that events will be emitted for.
         /// </summary>
-        [UnityFlag]
+        [UnityFlags]
         [Tooltip("The types of collisions that events will be emitted for.")]
         public CollisionTypes emittedTypes = (CollisionTypes)(-1);
 


### PR DESCRIPTION
The UnityFlags attribute was recently updated but the CollisionTracker
component was still using the old UnityFlag attribute.