### PR TITLE
fix(Tracking): explicitly specify time settings for rigidbody tests

### DIFF
--- a/Tests/Editor/Tracking/Follow/Modifier/ModifyRigidbodyVelocityTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/ModifyRigidbodyVelocityTest.cs
@@ -2,6 +2,7 @@
 {
     using UnityEngine;
     using NUnit.Framework;
+    using VRTK.Core.Utility;
 
     public class ModifyRigidbodyVelocityTest
     {
@@ -9,9 +10,13 @@
         private ModifyRigidbodyVelocity subject;
         private Rigidbody subjectRigidbody;
 
+        private TimeSettingOverride timeOverride;
+
         [SetUp]
         public void SetUp()
         {
+            timeOverride = new TimeSettingOverride(0.02f, 0.3333333f, 1f, 0.03f);
+
             containingObject = new GameObject();
             subject = containingObject.AddComponent<ModifyRigidbodyVelocity>();
             subjectRigidbody = containingObject.AddComponent<Rigidbody>();
@@ -23,6 +28,8 @@
             Object.DestroyImmediate(subjectRigidbody);
             Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
+
+            timeOverride.ResetTime();
         }
 
         [Test]

--- a/Tests/Utility/TimeSettingOverride.cs
+++ b/Tests/Utility/TimeSettingOverride.cs
@@ -1,0 +1,39 @@
+﻿namespace VRTK.Core.Utility
+{
+    using UnityEngine;
+
+    public class TimeSettingOverride
+    {
+        private float savedFixedDeltaTime;
+        private float savedMaximumDeltaTime;
+        private float savedTimeScale;
+        private float savedMaximumParticleDeltaTime;
+
+        public TimeSettingOverride()
+        {
+        }
+
+        public TimeSettingOverride(float fixedDeltaTime, float maximumDeltaTime, float timeScale, float maximumParticleDeltaTime)
+        {
+            OverrideTime(fixedDeltaTime, maximumDeltaTime, timeScale, maximumParticleDeltaTime);
+        }
+
+        public virtual void OverrideTime(float fixedDeltaTime, float maximumDeltaTime, float timeScale, float maximumParticleDeltaTime)
+        {
+            savedFixedDeltaTime = Time.fixedDeltaTime;
+            savedMaximumDeltaTime = Time.maximumDeltaTime;
+            savedTimeScale = Time.timeScale;
+            savedMaximumParticleDeltaTime = Time.maximumParticleDeltaTime;
+
+            Time.fixedDeltaTime = fixedDeltaTime;
+            Time.maximumDeltaTime = maximumDeltaTime;
+            Time.timeScale = timeScale;
+            Time.maximumParticleDeltaTime = maximumParticleDeltaTime;
+        }
+
+        public virtual void ResetTime()
+        {
+            OverrideTime(savedFixedDeltaTime, savedMaximumDeltaTime, savedTimeScale, savedMaximumParticleDeltaTime);
+        }
+    }
+}

--- a/Tests/Utility/TimeSettingOverride.cs.meta
+++ b/Tests/Utility/TimeSettingOverride.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c609e31b41462084bb9bc5c4ca257173
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Tests that rely on rigidbody information require explicit Unity time
settings otherwise the settings will affect the test results.

This has been fixed by providing a new test utility that can set the
time settings and then reset them back to the previous settings to
allow tests to run in the correct time state.