### PR TITLE
chore(Editor): ensure prefab changes are shown - resolves #159

### DIFF
--- a/Scripts/Data/Attribute/Editor/UnityFlagsDrawer.cs
+++ b/Scripts/Data/Attribute/Editor/UnityFlagsDrawer.cs
@@ -10,7 +10,11 @@
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             label.tooltip = EditorHelper.GetTooltipAttribute(fieldInfo)?.tooltip ?? string.Empty;
-            property.intValue = EditorGUI.MaskField(position, label, property.intValue, property.enumNames);
+
+            using (new EditorGUI.PropertyScope(position, GUIContent.none, property))
+            {
+                property.intValue = EditorGUI.MaskField(position, label, property.intValue, property.enumNames);
+            }
         }
     }
 }

--- a/Scripts/Data/Type/Editor/FloatRangeDrawer.cs
+++ b/Scripts/Data/Type/Editor/FloatRangeDrawer.cs
@@ -20,15 +20,25 @@
             float labelWidth = 30f;
             float fieldWidth = (position.width / 3f) - labelWidth;
 
-            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Min");
-            updatePositionX += labelWidth;
-            minimum.floatValue = EditorGUI.FloatField(new Rect(updatePositionX, position.y, fieldWidth, position.height), minimum.floatValue);
-            updatePositionX += fieldWidth;
+            using (new EditorGUI.PropertyScope(position, GUIContent.none, minimum))
+            {
+                EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Min");
+                updatePositionX += labelWidth;
+                minimum.floatValue = EditorGUI.FloatField(
+                    new Rect(updatePositionX, position.y, fieldWidth, position.height),
+                    minimum.floatValue);
+                updatePositionX += fieldWidth;
+            }
 
-            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Max");
-            updatePositionX += labelWidth;
-            maximum.floatValue = EditorGUI.FloatField(new Rect(updatePositionX, position.y, fieldWidth, position.height), maximum.floatValue);
-            updatePositionX += fieldWidth;
+            using (new EditorGUI.PropertyScope(position, GUIContent.none, maximum))
+            {
+                EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Max");
+                updatePositionX += labelWidth;
+                maximum.floatValue = EditorGUI.FloatField(
+                    new Rect(updatePositionX, position.y, fieldWidth, position.height),
+                    maximum.floatValue);
+                updatePositionX += fieldWidth;
+            }
 
             EditorGUI.indentLevel = indent;
         }

--- a/Scripts/Data/Type/Editor/Vector3StateDrawer.cs
+++ b/Scripts/Data/Type/Editor/Vector3StateDrawer.cs
@@ -20,20 +20,35 @@
             float labelWidth = 15f;
             float fieldWidth = (position.width / 3f) - labelWidth;
 
-            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "X");
-            updatePositionX += labelWidth;
-            xState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), xState.boolValue);
-            updatePositionX += fieldWidth;
+            using (new EditorGUI.PropertyScope(position, GUIContent.none, xState))
+            {
+                EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "X");
+                updatePositionX += labelWidth;
+                xState.boolValue = EditorGUI.Toggle(
+                    new Rect(updatePositionX, position.y, fieldWidth, position.height),
+                    xState.boolValue);
+                updatePositionX += fieldWidth;
+            }
 
-            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Y");
-            updatePositionX += labelWidth;
-            yState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), yState.boolValue);
-            updatePositionX += fieldWidth;
+            using (new EditorGUI.PropertyScope(position, GUIContent.none, yState))
+            {
+                EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Y");
+                updatePositionX += labelWidth;
+                yState.boolValue = EditorGUI.Toggle(
+                    new Rect(updatePositionX, position.y, fieldWidth, position.height),
+                    yState.boolValue);
+                updatePositionX += fieldWidth;
+            }
 
-            EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Z");
-            updatePositionX += labelWidth;
-            zState.boolValue = EditorGUI.Toggle(new Rect(updatePositionX, position.y, fieldWidth, position.height), zState.boolValue);
-            updatePositionX += fieldWidth;
+            using (new EditorGUI.PropertyScope(position, GUIContent.none, zState))
+            {
+                EditorGUI.LabelField(new Rect(updatePositionX, position.y, labelWidth, position.height), "Z");
+                updatePositionX += labelWidth;
+                zState.boolValue = EditorGUI.Toggle(
+                    new Rect(updatePositionX, position.y, fieldWidth, position.height),
+                    zState.boolValue);
+                updatePositionX += fieldWidth;
+            }
         }
     }
 }


### PR DESCRIPTION
By default Unity shows values that are part of a prefab instance
differently in case that value is changed compared to the prefab's
default value. This change ensures that Unity does the same to all
of the custom drawers.