### PR TITLE
feat(Follow): add rigidbody rotation by force follow modifier property

### DIFF
--- a/Scripts/Tracking/Follow/Modifier/Property/Rotation/RigidbodyForceAtPosition.cs
+++ b/Scripts/Tracking/Follow/Modifier/Property/Rotation/RigidbodyForceAtPosition.cs
@@ -1,0 +1,63 @@
+﻿namespace VRTK.Core.Tracking.Follow.Modifier.Property.Rotation
+{
+    using UnityEngine;
+    using VRTK.Core.Extension;
+
+    /// <summary>
+    /// Updates the rigidbody by applying force at the position difference between the source and the attachment point providing a torque rotation.
+    /// </summary>
+    public class RigidbodyForceAtPosition : PropertyModifier
+    {
+        /// <summary>
+        /// The point where the attachment was made.
+        /// </summary>
+        [Tooltip("The point where the attachment was made.")]
+        public GameObject attachmentPoint;
+
+        /// <summary>
+        /// A cached version of the target rigidbody.
+        /// </summary>
+        protected Rigidbody cachedTargetRigidbody;
+        /// <summary>
+        /// A cached version of the target.
+        /// </summary>
+        protected GameObject cachedTarget;
+
+        /// <summary>
+        /// Sets the attachment point.
+        /// </summary>
+        /// <param name="attachmentPoint">The new attachment point.</param>
+        public virtual void SetAttachmentPoint(GameObject attachmentPoint)
+        {
+            this.attachmentPoint = attachmentPoint;
+        }
+
+        /// <summary>
+        /// Clears the attachment point.
+        /// </summary>
+        public virtual void ClearAttachmentPoint()
+        {
+            attachmentPoint = null;
+        }
+
+        /// <summary>
+        /// Applies a force at the attachment point position to the target rigidbody creating torque for rotation.
+        /// </summary>
+        /// <param name="source">The source to utilize in the modification.</param>
+        /// <param name="target">The target to modify.</param>
+        /// <param name="offset">The offset of the target against the source when modifying.</param>
+        protected override void DoModify(GameObject source, GameObject target, GameObject offset = null)
+        {
+            cachedTargetRigidbody = (cachedTargetRigidbody == null || target != cachedTarget ? target.TryGetComponent<Rigidbody>(true) : cachedTargetRigidbody);
+            cachedTarget = target;
+
+            if (cachedTargetRigidbody == null || source == null || attachmentPoint == null)
+            {
+                return;
+            }
+
+            Vector3 rotationForce = source.transform.position - attachmentPoint.transform.position;
+            cachedTargetRigidbody.AddForceAtPosition(rotationForce, attachmentPoint.transform.position, ForceMode.VelocityChange);
+        }
+    }
+}

--- a/Scripts/Tracking/Follow/Modifier/Property/Rotation/RigidbodyForceAtPosition.cs.meta
+++ b/Scripts/Tracking/Follow/Modifier/Property/Rotation/RigidbodyForceAtPosition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2914d5d44743df44da82c8613cc7d32a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A new follow modifier property dealing with rotation has been added
that applies a force at a given position to a rigidbody which creates
a torque providing a rotation to the object.

This is useful for controlling objects that are attached on a hinge
joint.

As this is using actual forces it cannot be tested via the editor
tests.