### PR TITLE
feat(Rule): match against a collection of rules and emit event

### DIFF
--- a/Scripts/Rule/RulesMatcher.cs
+++ b/Scripts/Rule/RulesMatcher.cs
@@ -1,0 +1,56 @@
+﻿namespace VRTK.Core.Rule
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using System.Linq;
+    using System.Collections.Generic;
+    using VRTK.Core.Extension;
+
+    /// <summary>
+    /// Matches a given object against a collections of rules and emits the associated event.
+    /// </summary>
+    public class RulesMatcher : MonoBehaviour
+    {
+        /// <summary>
+        /// The rule and event association that can be matched against.
+        /// </summary>
+        [Serializable]
+        public class Element
+        {
+            /// <summary>
+            /// The rule to match against.
+            /// </summary>
+            [Tooltip("The rule to match against.")]
+            public RuleContainer rule;
+            /// <summary>
+            /// Emitted when the <see cref="rule"/> is valid.
+            /// </summary>
+            [Tooltip("Emitted when the rule is valid.")]
+            public UnityEvent Matched = new UnityEvent();
+        }
+
+        /// <summary>
+        /// A collection of rules to potentially match against.
+        /// </summary>
+        [Tooltip("A collection of rules to potentially match against.")]
+        public List<Element> elements = new List<Element>();
+
+        /// <summary>
+        /// Attempts to match the given object to the rules within the <see cref="elements"/> collection. If a match occurs then the appropriate event is emitted.
+        /// </summary>
+        /// <param name="source">The source to provide to the rule for validity checking.</param>
+        public virtual void Match(object source)
+        {
+            if (!isActiveAndEnabled)
+            {
+                return;
+            }
+
+            foreach (Element element in elements.EmptyIfNull().Where(target => target.rule.Accepts(source)))
+            {
+                element.Matched?.Invoke();
+            }
+        }
+    }
+}

--- a/Scripts/Rule/RulesMatcher.cs.meta
+++ b/Scripts/Rule/RulesMatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed4d8b391dc78854da24cb25b16ae490
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Rule/RulesMatcherTest.cs
+++ b/Tests/Editor/Rule/RulesMatcherTest.cs
@@ -1,0 +1,170 @@
+﻿using VRTK.Core.Rule;
+
+namespace Test.VRTK.Core.Rule
+{
+    using UnityEngine;
+    using NUnit.Framework;
+    using Test.VRTK.Core.Utility.Mock;
+
+    public class RulesMatcherTest
+    {
+        private GameObject containingObject;
+        private RulesMatcher subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<RulesMatcher>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void Match()
+        {
+            GameObject objectOne = new GameObject();
+            GameObject objectTwo = new GameObject();
+            UnityEventListenerMock ruleOneMatched = new UnityEventListenerMock();
+            UnityEventListenerMock ruleTwoMatched = new UnityEventListenerMock();
+
+            RulesMatcher.Element elementOne = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
+            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { rule = CreateRule(objectTwo) };
+
+            elementOne.Matched.AddListener(ruleOneMatched.Listen);
+            elementTwo.Matched.AddListener(ruleTwoMatched.Listen);
+
+            subject.elements.Add(elementOne);
+            subject.elements.Add(elementTwo);
+
+            Assert.IsFalse(ruleOneMatched.Received);
+            Assert.IsFalse(ruleTwoMatched.Received);
+
+            subject.Match(objectOne);
+
+            Assert.IsTrue(ruleOneMatched.Received);
+            Assert.IsFalse(ruleTwoMatched.Received);
+
+            ruleOneMatched.Reset();
+            ruleTwoMatched.Reset();
+
+            subject.Match(objectTwo);
+
+            Assert.IsFalse(ruleOneMatched.Received);
+            Assert.IsTrue(ruleTwoMatched.Received);
+
+            Object.DestroyImmediate(objectOne);
+            Object.DestroyImmediate(objectTwo);
+        }
+
+        [Test]
+        public void MatchMultiple()
+        {
+            GameObject objectOne = new GameObject();
+            GameObject objectTwo = new GameObject();
+            UnityEventListenerMock ruleOneMatched = new UnityEventListenerMock();
+            UnityEventListenerMock ruleTwoMatched = new UnityEventListenerMock();
+            UnityEventListenerMock ruleThreeMatched = new UnityEventListenerMock();
+
+            RulesMatcher.Element elementOne = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
+            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { rule = CreateRule(objectTwo) };
+            RulesMatcher.Element elementThree = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
+
+            elementOne.Matched.AddListener(ruleOneMatched.Listen);
+            elementTwo.Matched.AddListener(ruleTwoMatched.Listen);
+            elementThree.Matched.AddListener(ruleThreeMatched.Listen);
+
+            subject.elements.Add(elementOne);
+            subject.elements.Add(elementTwo);
+            subject.elements.Add(elementThree);
+
+            Assert.IsFalse(ruleOneMatched.Received);
+            Assert.IsFalse(ruleTwoMatched.Received);
+            Assert.IsFalse(ruleThreeMatched.Received);
+
+            subject.Match(objectOne);
+
+            Assert.IsTrue(ruleOneMatched.Received);
+            Assert.IsFalse(ruleTwoMatched.Received);
+            Assert.IsTrue(ruleThreeMatched.Received);
+
+            Object.DestroyImmediate(objectOne);
+            Object.DestroyImmediate(objectTwo);
+        }
+
+        [Test]
+        public void MatchInactiveGameObject()
+        {
+            GameObject objectOne = new GameObject();
+            GameObject objectTwo = new GameObject();
+            UnityEventListenerMock ruleOneMatched = new UnityEventListenerMock();
+            UnityEventListenerMock ruleTwoMatched = new UnityEventListenerMock();
+
+            RulesMatcher.Element elementOne = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
+            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { rule = CreateRule(objectTwo) };
+
+            elementOne.Matched.AddListener(ruleOneMatched.Listen);
+            elementTwo.Matched.AddListener(ruleTwoMatched.Listen);
+
+            subject.elements.Add(elementOne);
+            subject.elements.Add(elementTwo);
+
+            subject.gameObject.SetActive(false);
+
+            Assert.IsFalse(ruleOneMatched.Received);
+            Assert.IsFalse(ruleTwoMatched.Received);
+
+            subject.Match(objectOne);
+
+            Assert.IsFalse(ruleOneMatched.Received);
+            Assert.IsFalse(ruleTwoMatched.Received);
+
+            Object.DestroyImmediate(objectOne);
+            Object.DestroyImmediate(objectTwo);
+        }
+
+        [Test]
+        public void MatchInactiveComponent()
+        {
+            GameObject objectOne = new GameObject();
+            GameObject objectTwo = new GameObject();
+            UnityEventListenerMock ruleOneMatched = new UnityEventListenerMock();
+            UnityEventListenerMock ruleTwoMatched = new UnityEventListenerMock();
+
+            RulesMatcher.Element elementOne = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
+            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { rule = CreateRule(objectTwo) };
+
+            elementOne.Matched.AddListener(ruleOneMatched.Listen);
+            elementTwo.Matched.AddListener(ruleTwoMatched.Listen);
+
+            subject.elements.Add(elementOne);
+            subject.elements.Add(elementTwo);
+
+            subject.enabled = false;
+
+            Assert.IsFalse(ruleOneMatched.Received);
+            Assert.IsFalse(ruleTwoMatched.Received);
+
+            subject.Match(objectOne);
+
+            Assert.IsFalse(ruleOneMatched.Received);
+            Assert.IsFalse(ruleTwoMatched.Received);
+
+            Object.DestroyImmediate(objectOne);
+            Object.DestroyImmediate(objectTwo);
+        }
+
+        protected virtual RuleContainer CreateRule(GameObject element)
+        {
+            RuleContainer container = new RuleContainer();
+            ListContainsRule rule = containingObject.AddComponent<ListContainsRule>();
+            rule.objects.Add(element);
+            container.Interface = rule;
+            return container;
+        }
+    }
+}

--- a/Tests/Editor/Rule/RulesMatcherTest.cs.meta
+++ b/Tests/Editor/Rule/RulesMatcherTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 652056ba8150e7543bfcdf4a94f8fc2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The RulesMatcher allows a for a List of rules to be provided with
an associated event for each rule. When the `Match` method is called
with a source GameObject, any rule in the list that matches based
on the given GameObject will emit the associated event.