### PR TITLE
feat(CameraRig): expose alias tracking begun events

### DIFF
--- a/Prefabs/CameraRig/TrackedAlias/SharedResources/Scripts/TrackedAliasFacade.cs
+++ b/Prefabs/CameraRig/TrackedAlias/SharedResources/Scripts/TrackedAliasFacade.cs
@@ -1,6 +1,7 @@
 ﻿namespace VRTK.Core.Prefabs.CameraRig.TrackedAlias
 {
     using UnityEngine;
+    using UnityEngine.Events;
     using System.Collections.Generic;
     using System.Linq;
     using VRTK.Core.Extension;
@@ -19,6 +20,22 @@
         /// </summary>
         [Header("Tracked Alias Settings"), Tooltip("The associated CameraRigs to track.")]
         public List<BaseAliasAssociationCollection> cameraRigs = new List<BaseAliasAssociationCollection>();
+        #endregion
+
+        #region Tracking Begun Events
+        /// <summary>
+        /// Emitted when the headset starts tracking for the first time.
+        /// </summary>
+        [Header("Tracking Begun Events")]
+        public UnityEvent HeadsetTrackingBegun = new UnityEvent();
+        /// <summary>
+        /// Emitted when the left controller starts tracking for the first time.
+        /// </summary>
+        public UnityEvent LeftControllerTrackingBegun = new UnityEvent();
+        /// <summary>
+        /// Emitted when the right controller starts tracking for the first time.
+        /// </summary>
+        public UnityEvent RightControllerTrackingBegun = new UnityEvent();
         #endregion
 
         #region Internal Settings

--- a/Prefabs/CameraRig/TrackedAlias/SharedResources/Scripts/TrackedAliasInternalSetup.cs
+++ b/Prefabs/CameraRig/TrackedAlias/SharedResources/Scripts/TrackedAliasInternalSetup.cs
@@ -107,6 +107,30 @@
             rightControllerVelocityTrackers.velocityTrackers.Clear();
         }
 
+        /// <summary>
+        /// Notifies that the headset has started being tracked.
+        /// </summary>
+        public virtual void NotifyHeadsetTrackingBegun()
+        {
+            facade?.HeadsetTrackingBegun?.Invoke();
+        }
+
+        /// <summary>
+        /// Notifies that the left controller has started being tracked.
+        /// </summary>
+        public virtual void NotifyLeftControllerTrackingBegun()
+        {
+            facade?.LeftControllerTrackingBegun?.Invoke();
+        }
+
+        /// <summary>
+        /// Notifies that the right controller has started being tracked.
+        /// </summary>
+        public virtual void NotifyRightControllerTrackingBegun()
+        {
+            facade?.RightControllerTrackingBegun?.Invoke();
+        }
+
         protected virtual void OnEnable()
         {
             Setup();

--- a/Prefabs/CameraRig/TrackedAlias/[VRTK_TrackedAlias].prefab
+++ b/Prefabs/CameraRig/TrackedAlias/[VRTK_TrackedAlias].prefab
@@ -617,6 +617,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 114148444839838400}
+        m_MethodName: NotifyHeadsetTrackingBegun
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ThresholdResumed:
@@ -767,6 +778,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 114148444839838400}
+        m_MethodName: NotifyLeftControllerTrackingBegun
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   ThresholdResumed:
@@ -809,6 +831,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cameraRigs: []
+  HeadsetTrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  LeftControllerTrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  RightControllerTrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
   internalSetup: {fileID: 114148444839838400}
 --- !u!114 &114644331804853310
 MonoBehaviour:
@@ -979,6 +1016,17 @@ MonoBehaviour:
       - m_Target: {fileID: 1881132033643546}
         m_MethodName: SetActive
         m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 114148444839838400}
+        m_MethodName: NotifyRightControllerTrackingBegun
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine


### PR DESCRIPTION
The TrackedAlias prefab has internal events to know when the relevant
alias elements have begun tracking, these are now exposed to the facade
so it is easier to wire up actions on these events without needing to
go into the underlying structure.