### PR TITLE
feat(Interaction): add grab/ungrab helper methods to interactors

### DIFF
--- a/Prefabs/Interactions/Interactables/SharedResources/Scripts/GrabInteractableInternalSetup.cs
+++ b/Prefabs/Interactions/Interactables/SharedResources/Scripts/GrabInteractableInternalSetup.cs
@@ -198,7 +198,7 @@
         /// <param name="interactor">The Interactor to attach the Interactable to.</param>
         public virtual void Grab(InteractorFacade interactor)
         {
-            doGrab?.Receive(ConsumerDataFromInteractor(interactor));
+            interactor?.Grab(facade);
         }
 
         /// <summary>
@@ -213,7 +213,16 @@
                 return;
             }
 
-            doUngrab.Receive(ConsumerDataFromInteractor(currentInteractors[sequenceIndex]));
+            Ungrab(currentInteractors[sequenceIndex]);
+        }
+
+        /// <summary>
+        /// Attempts to ungrab the Interactable.
+        /// </summary>
+        /// <param name="interactor">The Interactor to ungrab from.</param>
+        public virtual void Ungrab(InteractorFacade interactor)
+        {
+            interactor?.Ungrab();
         }
 
         /// <summary>
@@ -222,7 +231,7 @@
         /// <param name="data">The grabbing object.</param>
         public virtual void NotifyFirstGrab(GameObject data)
         {
-            InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(data);
+            InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
                 facade?.FirstGrabbed?.Invoke(interactor);
@@ -235,7 +244,7 @@
         /// <param name="data">The grabbing object.</param>
         public virtual void NotifyGrab(GameObject data)
         {
-            InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(data);
+            InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
                 facade?.Grabbed?.Invoke(interactor);
@@ -250,7 +259,7 @@
         /// <param name="data">The previous grabbing object.</param>
         public virtual void NotifyUngrab(GameObject data)
         {
-            InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(data);
+            InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
                 facade?.Ungrabbed?.Invoke(interactor);
@@ -265,7 +274,7 @@
         /// <param name="data">The ungrabbing object.</param>
         public virtual void NotifyLastUngrab(GameObject data)
         {
-            InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(data);
+            InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
                 facade?.LastUngrabbed?.Invoke(interactor);
@@ -280,7 +289,12 @@
             ConfigureGrabValidity();
         }
 
-        protected virtual ActiveCollisionConsumer.EventData ConsumerDataFromInteractor(InteractorFacade interactor)
+        /// <summary>
+        /// Creates consumer data from a given Interactor.
+        /// </summary>
+        /// <param name="interactor">The Interactor to create from.</param>
+        /// <returns>The created consumer data.</returns>
+        protected virtual ActiveCollisionConsumer.EventData CreateConsumerDataFromInteractor(InteractorFacade interactor)
         {
             ActiveCollisionPublisher.PayloadData interactorPublisher = new ActiveCollisionPublisher.PayloadData();
             interactorPublisher.sourceContainer = interactor?.grabInteractorSetup?.attachPoint;
@@ -302,7 +316,7 @@
 
             foreach (GameObject element in gameObjectEventStack.Stack)
             {
-                InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(element);
+                InteractorFacade interactor = element.TryGetComponent<InteractorFacade>(true, true);
                 if (interactor != null)
                 {
                     returnList.Add(interactor);

--- a/Prefabs/Interactions/Interactables/SharedResources/Scripts/InteractableFacade.cs
+++ b/Prefabs/Interactions/Interactables/SharedResources/Scripts/InteractableFacade.cs
@@ -4,6 +4,7 @@
     using UnityEngine.Events;
     using System;
     using System.Collections.Generic;
+    using VRTK.Core.Extension;
     using VRTK.Core.Data.Attribute;
     using VRTK.Core.Prefabs.Interactions.Interactors;
 
@@ -163,6 +164,15 @@
         public List<InteractorFacade> GrabbingInteractors => grabInteractableSetup?.GrabbingInteractors;
 
         /// <summary>
+        /// Attempt to grab the Interactable to the given <see cref="GameObject"/> that contains an Interactor.
+        /// </summary>
+        /// <param name="interactor">The GameObject that the Interactor is on.</param>
+        public virtual void Grab(GameObject interactor)
+        {
+            Grab(interactor.TryGetComponent<InteractorFacade>(true, true));
+        }
+
+        /// <summary>
         /// Attempt to grab the Interactable to the given Interactor.
         /// </summary>
         /// <param name="interactor">The Interactor to attach the Interactable to.</param>
@@ -172,12 +182,30 @@
         }
 
         /// <summary>
+        /// Attempt to ungrab the Interactable to the given <see cref="GameObject"/> that contains an Interactor.
+        /// </summary>
+        /// <param name="interactor">The GameObject that the Interactor is on.</param>
+        public virtual void Ungrab(GameObject interactor)
+        {
+            Ungrab(interactor.TryGetComponent<InteractorFacade>(true, true));
+        }
+
+        /// <summary>
         /// Attempt to ungrab the Interactable.
+        /// </summary>
+        /// <param name="interactor">The Interactor to ungrab from.</param>
+        public virtual void Ungrab(InteractorFacade interactor)
+        {
+            grabInteractableSetup?.Ungrab(interactor);
+        }
+
+        /// <summary>
+        /// Attempt to ungrab the Interactable at a specific grabbing index.
         /// </summary>
         /// <param name="sequenceIndex">The Interactor sequence index to ungrab from.</param>
         public virtual void Ungrab(int sequenceIndex = 0)
         {
-            grabInteractableSetup.Ungrab(sequenceIndex);
+            grabInteractableSetup?.Ungrab(sequenceIndex);
         }
 
         /// <summary>

--- a/Prefabs/Interactions/Interactables/SharedResources/Scripts/TouchInteractableInternalSetup.cs
+++ b/Prefabs/Interactions/Interactables/SharedResources/Scripts/TouchInteractableInternalSetup.cs
@@ -3,8 +3,8 @@
     using UnityEngine;
     using System.Collections.Generic;
     using VRTK.Core.Rule;
+    using VRTK.Core.Extension;
     using VRTK.Core.Data.Collection;
-    using VRTK.Core.Tracking.Collision;
     using VRTK.Core.Prefabs.Interactions.Interactors;
 
     public class TouchInteractableInternalSetup : MonoBehaviour
@@ -59,7 +59,7 @@
         /// <param name="data">The touching object.</param>
         public virtual void NotifyFirstTouch(GameObject data)
         {
-            InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(data);
+            InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
                 facade?.FirstTouched?.Invoke(interactor);
@@ -72,7 +72,7 @@
         /// <param name="data">The touching object.</param>
         public virtual void NotifyTouch(GameObject data)
         {
-            InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(data);
+            InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
                 facade?.Touched?.Invoke(interactor);
@@ -86,7 +86,7 @@
         /// <param name="data">The previous touching object.</param>
         public virtual void NotifyUntouch(GameObject data)
         {
-            InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(data);
+            InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
                 facade?.Untouched?.Invoke(interactor);
@@ -100,7 +100,7 @@
         /// <param name="data">The touching object.</param>
         public virtual void NotifyLastUntouch(GameObject data)
         {
-            InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(data);
+            InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
                 facade?.LastUntouched?.Invoke(interactor);
@@ -127,7 +127,7 @@
 
             foreach (GameObject element in currentTouchingObjects.Elements)
             {
-                InteractorFacade interactor = InteractorFacade.TryGetFromGameObject(element);
+                InteractorFacade interactor = element.TryGetComponent<InteractorFacade>(true, true);
                 if (interactor != null)
                 {
                     returnList.Add(interactor);

--- a/Prefabs/Interactions/Interactors/SharedResources/Scripts/GrabInteractorInternalSetup.cs
+++ b/Prefabs/Interactions/Interactors/SharedResources/Scripts/GrabInteractorInternalSetup.cs
@@ -3,9 +3,12 @@
     using UnityEngine;
     using System.Collections.Generic;
     using VRTK.Core.Action;
+    using VRTK.Core.Extension;
     using VRTK.Core.Data.Collection;
-    using VRTK.Core.Tracking.Collision.Active;
     using VRTK.Core.Tracking.Velocity;
+    using VRTK.Core.Tracking.Collision;
+    using VRTK.Core.Tracking.Collision.Active;
+    using VRTK.Core.Prefabs.Interactions.Interactables;
 
     /// <summary>
     /// Sets up the Interactor Prefab grab settings based on the provided user settings.
@@ -97,6 +100,58 @@
             }
         }
 
+        /// <summary>
+        /// Attempt to grab an Interactable to the current Interactor utilising custom collision data.
+        /// </summary>
+        /// <param name="interactable">The Interactable to attempt to grab.</param>
+        /// <param name="collision">Custom collision data.</param>
+        /// <param name="collider">Custom collider data.</param>
+        public virtual void Grab(InteractableFacade interactable, Collision collision, Collider collider)
+        {
+            if (interactable == null)
+            {
+                return;
+            }
+
+            Ungrab();
+            startGrabbingPublisher?.SetActiveCollisions(CreateActiveCollisionsEventData(interactable.gameObject, collision, collider));
+            ProcessGrabAction(startGrabbingPublisher, true);
+            if (interactable.grabType == InteractableFacade.ActiveType.Toggle)
+            {
+                ProcessGrabAction(startGrabbingPublisher, false);
+            }
+        }
+
+        /// <summary>
+        /// Attempt to ungrab currently grabbed Interactables to the current Interactor.
+        /// </summary>
+        public virtual void Ungrab()
+        {
+            if (GrabbedObjects.Count == 0)
+            {
+                return;
+            }
+
+            InteractableFacade interactable = GrabbedObjects[0].TryGetComponent<InteractableFacade>(true, true);
+            if (interactable.grabType == InteractableFacade.ActiveType.Toggle)
+            {
+                ProcessGrabAction(startGrabbingPublisher, true);
+            }
+            ProcessGrabAction(stopGrabbingPublisher, false);
+        }
+
+        protected virtual void ProcessGrabAction(ActiveCollisionPublisher publisher, bool actionState)
+        {
+            if (grabAction?.Value != actionState)
+            {
+                grabAction?.Receive(actionState);
+            }
+            else
+            {
+                publisher?.Publish();
+            }
+        }
+
         protected virtual void OnEnable()
         {
             ConfigureGrabAction();
@@ -119,6 +174,18 @@
 
             returnList.AddRange(grabbedObjects.Elements);
             return returnList;
+        }
+
+        protected virtual ActiveCollisionsContainer.EventData CreateActiveCollisionsEventData(GameObject forwardSource, Collision collision = null, Collider collider = null)
+        {
+            collider = (collider == null ? forwardSource.GetComponentInChildren<Collider>() : collider);
+            CollisionNotifier.EventData collisionPayload = new CollisionNotifier.EventData();
+            collisionPayload.Set(forwardSource.TryGetComponent<Component>(), collider.isTrigger, collision, collider);
+            ActiveCollisionsContainer.EventData activeCollisionPayload = new ActiveCollisionsContainer.EventData();
+            List<CollisionNotifier.EventData> collisionList = new List<CollisionNotifier.EventData>();
+            collisionList.Add(collisionPayload);
+            activeCollisionPayload.Set(collisionList);
+            return activeCollisionPayload;
         }
     }
 }

--- a/Prefabs/Interactions/Interactors/SharedResources/Scripts/InteractorFacade.cs
+++ b/Prefabs/Interactions/Interactors/SharedResources/Scripts/InteractorFacade.cs
@@ -5,9 +5,10 @@
     using System;
     using System.Collections.Generic;
     using VRTK.Core.Action;
+    using VRTK.Core.Extension;
+    using VRTK.Core.Data.Attribute;
     using VRTK.Core.Tracking.Velocity;
     using VRTK.Core.Prefabs.Interactions.Interactables;
-    using VRTK.Core.Data.Attribute;
 
     /// <summary>
     /// The public interface into the Interactor Prefab.
@@ -82,27 +83,40 @@
         public List<GameObject> GrabbedObjects => grabInteractorSetup?.GrabbedObjects;
 
         /// <summary>
-        /// Attempts to retrieve from a given GameObject.
+        /// Attempt to grab a <see cref="GameObject"/> that contains an Interactable to the current Interactor.
         /// </summary>
-        /// <param name="data">The GameObject to retreive from.</param>
-        /// <param name="searchChildren">Optionally searches the children of the given GameObject.</param>
-        /// <param name="searchParents">Optionally searches the parents of the given GameObject.</param>
-        /// <returns>The found Interactor.</returns>
-        public static InteractorFacade TryGetFromGameObject(GameObject data, bool searchChildren = true, bool searchParents = true)
+        /// <param name="interactor">The GameObject that the Interactor is on.</param>
+        public virtual void Grab(GameObject interactable)
         {
-            InteractorFacade returnFacade = data.GetComponent<InteractorFacade>();
+            Grab(interactable.TryGetComponent<InteractableFacade>(true, true));
+        }
 
-            if (searchChildren && returnFacade == null)
-            {
-                returnFacade = data.GetComponentInChildren<InteractorFacade>();
-            }
+        /// <summary>
+        /// Attempt to grab an Interactable to the current Interactor.
+        /// </summary>
+        /// <param name="interactable">The Interactable to attempt to grab.</param>
+        public virtual void Grab(InteractableFacade interactable)
+        {
+            Grab(interactable, null, null);
+        }
 
-            if (searchParents && returnFacade == null)
-            {
-                returnFacade = data.GetComponentInParent<InteractorFacade>();
-            }
+        /// <summary>
+        /// Attempt to grab an Interactable to the current Interactor utilising custom collision data.
+        /// </summary>
+        /// <param name="interactable">The Interactable to attempt to grab.</param>
+        /// <param name="collision">Custom collision data.</param>
+        /// <param name="collider">Custom collider data.</param>
+        public virtual void Grab(InteractableFacade interactable, Collision collision, Collider collider)
+        {
+            grabInteractorSetup?.Grab(interactable, collision, collider);
+        }
 
-            return returnFacade;
+        /// <summary>
+        /// Attempt to ungrab currently grabbed Interactables to the current Interactor.
+        /// </summary>
+        public virtual void Ungrab()
+        {
+            grabInteractorSetup?.Ungrab();
         }
     }
 }

--- a/Scripts/Tracking/Collision/Active/ActiveCollisionPublisher.cs
+++ b/Scripts/Tracking/Collision/Active/ActiveCollisionPublisher.cs
@@ -123,7 +123,7 @@
         /// <returns>The obtained collection.</returns>
         protected virtual IEnumerable<ActiveCollisionConsumer> GetConsumers(Transform reference)
         {
-            if (transform.IsChildOf(reference))
+            if (reference == null || transform.IsChildOf(reference))
             {
                 return Enumerable.Empty<ActiveCollisionConsumer>();
             }


### PR DESCRIPTION
The InteractorFacade now has a Grab and Ungrab helper method that
allows an Interactable to be passed to a specific Interactor to
initiate a grab (or alternatively ungrab).

This makes it possible to initiate a grab/ungrab from either the
Interactor or the Interactable.