### PR TITLE
fix(Transformation): use vector multiplier

### DIFF
--- a/Prefabs/CameraRig/SimulatedCameraRig/[SimulatedCameraRig].prefab
+++ b/Prefabs/CameraRig/SimulatedCameraRig/[SimulatedCameraRig].prefab
@@ -3382,8 +3382,7 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Data.Type.Transformation.Vector2Multiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  xMultiplier: 1
-  yMultiplier: -1
+  multiplier: {x: 1, y: -1}
 --- !u!114 &114886786870708734
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Scripts/Data/Type/Transformation/Vector2Multiplier.cs
+++ b/Scripts/Data/Type/Transformation/Vector2Multiplier.cs
@@ -21,15 +21,19 @@
         }
 
         /// <summary>
-        /// The value to multiply the x coordinate by.
+        /// The value to multiply the input by.
         /// </summary>
-        [Tooltip("The value to multiply the x coordinate by."), SerializeField]
-        protected float xMultiplier = 1f;
+        [Tooltip("The value to multiply the input by."), SerializeField]
+        protected Vector2 multiplier = Vector2.one;
+
         /// <summary>
-        /// The value to multiply the y coordinate by.
+        /// Sets the value to multiply the input by.
         /// </summary>
-        [Tooltip("The value to multiply the y coordinate by."), SerializeField]
-        protected float yMultiplier = 1f;
+        /// <param name="multiplier">The new multiplier value.</param>
+        public virtual void SetMultiplier(Vector2 multiplier)
+        {
+            this.multiplier = multiplier;
+        }
 
         /// <summary>
         /// Sets the x value to multiply the input x by.
@@ -37,7 +41,7 @@
         /// <param name="xMultiplier">The new x multiplier value.</param>
         public virtual void SetXMultiplier(float xMultiplier)
         {
-            this.xMultiplier = xMultiplier;
+            multiplier.x = xMultiplier;
         }
 
         /// <summary>
@@ -46,7 +50,7 @@
         /// <param name="yMultiplier">The new y multiplier value.</param>
         public virtual void SetYMultiplier(float yMultiplier)
         {
-            this.yMultiplier = yMultiplier;
+            multiplier.y = yMultiplier;
         }
 
         /// <summary>
@@ -56,7 +60,7 @@
         /// <returns>The transformed value.</returns>
         protected override Vector2 Process(Vector2 input)
         {
-            return new Vector2(input.x * xMultiplier, input.y * yMultiplier);
+            return Vector2.Scale(input, multiplier);
         }
     }
 }


### PR DESCRIPTION
The Vector2Multiplier was using two floats as the multiplier to use
in the operation this type implements. A Vector2 is a better
replacement for those floats and supports the same operations. The
existing setter methods are kept so per-axis changes are possible
via Editor inspectors while this change additionally allows
specifying a Vector2 directly.