### PR TITLE
fix(CameraRig): don't change time settings at edit-time

### DIFF
--- a/Prefabs/CameraRig/UnityXRCameraRig/SharedResources/Scripts/UnityXRConfiguration.cs
+++ b/Prefabs/CameraRig/UnityXRCameraRig/SharedResources/Scripts/UnityXRConfiguration.cs
@@ -59,7 +59,7 @@
 
         protected virtual void OnValidate()
         {
-            if (!isActiveAndEnabled)
+            if (!isActiveAndEnabled || !Application.isPlaying)
             {
                 return;
             }


### PR DESCRIPTION
The configuration component for the Unity XR settings was changing
the project time settings while in the editor and not playing. Since
the XR device is not loaded at edit-time this resulted in wrong time
settings. The fix is to only run the setting logic when playing.