### PR TITLE
fix(Structure): remove erroneous uses of monadic null checks - fixes #175

### DIFF
--- a/Prefabs/CameraRig/SimulatedCameraRig/SharedResources/Scripts/SimulatorConfiguration.cs
+++ b/Prefabs/CameraRig/SimulatedCameraRig/SharedResources/Scripts/SimulatorConfiguration.cs
@@ -93,12 +93,12 @@
             {
                 if (playareaPosition != null)
                 {
-                    playareaPosition.target = trackedAlias.internalSetup?.playArea?.sourceComponent?.gameObject;
+                    playareaPosition.target = trackedAlias.internalSetup.playArea.sourceComponent.gameObject;
                 }
 
                 if (playareaResetter != null)
                 {
-                    playareaResetter.source = trackedAlias.internalSetup?.playArea?.sourceComponent?.TryGetTransform();
+                    playareaResetter.source = trackedAlias.internalSetup.playArea.sourceComponent.TryGetTransform();
                 }
             }
         }

--- a/Prefabs/CameraRig/TrackedAlias/SharedResources/Scripts/TrackedAliasInternalSetup.cs
+++ b/Prefabs/CameraRig/TrackedAlias/SharedResources/Scripts/TrackedAliasInternalSetup.cs
@@ -112,7 +112,7 @@
         /// </summary>
         public virtual void NotifyHeadsetTrackingBegun()
         {
-            facade?.HeadsetTrackingBegun?.Invoke();
+            facade.HeadsetTrackingBegun?.Invoke();
         }
 
         /// <summary>
@@ -120,7 +120,7 @@
         /// </summary>
         public virtual void NotifyLeftControllerTrackingBegun()
         {
-            facade?.LeftControllerTrackingBegun?.Invoke();
+            facade.LeftControllerTrackingBegun?.Invoke();
         }
 
         /// <summary>
@@ -128,7 +128,7 @@
         /// </summary>
         public virtual void NotifyRightControllerTrackingBegun()
         {
-            facade?.RightControllerTrackingBegun?.Invoke();
+            facade.RightControllerTrackingBegun?.Invoke();
         }
 
         protected virtual void OnEnable()

--- a/Prefabs/Interactions/Interactables/SharedResources/Scripts/GrabInteractableInternalSetup.cs
+++ b/Prefabs/Interactions/Interactables/SharedResources/Scripts/GrabInteractableInternalSetup.cs
@@ -114,7 +114,7 @@
         /// </summary>
         public virtual void ConfigureGrabValidity()
         {
-            if (facade?.disallowedGrabInteractors == null || grabValidity == null)
+            if (facade.disallowedGrabInteractors == null || grabValidity == null)
             {
                 return;
             }
@@ -123,7 +123,7 @@
 
             foreach (InteractorFacade interactor in facade.disallowedGrabInteractors)
             {
-                if (interactor.grabInteractorSetup?.attachPoint != null)
+                if (interactor.grabInteractorSetup.attachPoint != null)
                 {
                     grabValidity.objects.Add(interactor.grabInteractorSetup.attachPoint);
                 }
@@ -135,7 +135,7 @@
         /// </summary>
         public virtual void ConfigureGrabOffset()
         {
-            switch (facade?.grabOffset)
+            switch (facade.grabOffset)
             {
                 case InteractableFacade.GrabOffset.None:
                     precisionGrabLogic.TrySetActive(false);
@@ -162,16 +162,16 @@
                 return;
             }
 
-            switch (facade?.trackingType)
+            switch (facade.trackingType)
             {
                 case InteractableFacade.TrackingType.FollowTransform:
-                    RigidbodyTracking?.gameObject.SetActive(false);
-                    TransformTracking?.gameObject.SetActive(true);
+                    RigidbodyTracking.gameObject.SetActive(false);
+                    TransformTracking.gameObject.SetActive(true);
                     attachmentLogic.followModifier = TransformTracking;
                     break;
                 case InteractableFacade.TrackingType.FollowRigidbody:
-                    TransformTracking?.gameObject.SetActive(false);
-                    RigidbodyTracking?.gameObject.SetActive(true);
+                    TransformTracking.gameObject.SetActive(false);
+                    RigidbodyTracking.gameObject.SetActive(true);
                     attachmentLogic.followModifier = RigidbodyTracking;
                     break;
             }
@@ -182,7 +182,7 @@
         /// </summary>
         public virtual void ConfigureGrabType()
         {
-            switch (facade?.grabType)
+            switch (facade.grabType)
             {
                 case InteractableFacade.ActiveType.HoldTillRelease:
                     StartStateGrab.TrySetActive(true);
@@ -203,7 +203,7 @@
         /// <param name="interactor">The Interactor to attach the Interactable to.</param>
         public virtual void Grab(InteractorFacade interactor)
         {
-            interactor?.Grab(facade);
+            interactor.Grab(facade);
         }
 
         /// <summary>
@@ -227,7 +227,7 @@
         /// <param name="interactor">The Interactor to ungrab from.</param>
         public virtual void Ungrab(InteractorFacade interactor)
         {
-            interactor?.Ungrab();
+            interactor.Ungrab();
         }
 
         /// <summary>
@@ -239,13 +239,13 @@
             InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
-                if (facade?.GrabbingInteractors.Count == 1)
+                if (facade.GrabbingInteractors.Count == 1)
                 {
-                    facade?.FirstGrabbed?.Invoke(interactor);
+                    facade.FirstGrabbed?.Invoke(interactor);
                 }
-                facade?.Grabbed?.Invoke(interactor);
+                facade.Grabbed?.Invoke(interactor);
                 interactor.Grabbed?.Invoke(facade);
-                interactor.grabInteractorSetup?.grabbedObjects?.AddElement(facade?.gameObject);
+                interactor.grabInteractorSetup.grabbedObjects.AddElement(facade.gameObject);
             }
         }
 
@@ -258,12 +258,12 @@
             InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
-                facade?.Ungrabbed?.Invoke(interactor);
+                facade.Ungrabbed?.Invoke(interactor);
                 interactor.Ungrabbed?.Invoke(facade);
-                interactor.grabInteractorSetup?.grabbedObjects?.RemoveElement(facade?.gameObject);
-                if (facade?.GrabbingInteractors.Count == 0)
+                interactor.grabInteractorSetup.grabbedObjects.RemoveElement(facade.gameObject);
+                if (facade.GrabbingInteractors.Count == 0)
                 {
-                    facade?.LastUngrabbed?.Invoke(interactor);
+                    facade.LastUngrabbed?.Invoke(interactor);
                 }
             }
         }
@@ -284,7 +284,7 @@
         protected virtual ActiveCollisionConsumer.EventData CreateConsumerDataFromInteractor(InteractorFacade interactor)
         {
             ActiveCollisionPublisher.PayloadData interactorPublisher = new ActiveCollisionPublisher.PayloadData();
-            interactorPublisher.sourceContainer = interactor?.grabInteractorSetup?.attachPoint;
+            interactorPublisher.sourceContainer = interactor.grabInteractorSetup.attachPoint;
             return new ActiveCollisionConsumer.EventData().Set(interactorPublisher, null);
         }
 

--- a/Prefabs/Interactions/Interactables/SharedResources/Scripts/InteractableFacade.cs
+++ b/Prefabs/Interactions/Interactables/SharedResources/Scripts/InteractableFacade.cs
@@ -157,11 +157,11 @@
         /// <summary>
         /// A collection of Interactors that are currently touching the Interactable.
         /// </summary>
-        public List<InteractorFacade> TouchingInteractors => touchInteractableSetup?.TouchingInteractors;
+        public List<InteractorFacade> TouchingInteractors => touchInteractableSetup.TouchingInteractors;
         /// <summary>
         /// A collection of Interactors that are currently grabbing the Interactable.
         /// </summary>
-        public List<InteractorFacade> GrabbingInteractors => grabInteractableSetup?.GrabbingInteractors;
+        public List<InteractorFacade> GrabbingInteractors => grabInteractableSetup.GrabbingInteractors;
 
         /// <summary>
         /// Attempt to grab the Interactable to the given <see cref="GameObject"/> that contains an Interactor.
@@ -178,7 +178,7 @@
         /// <param name="interactor">The Interactor to attach the Interactable to.</param>
         public virtual void Grab(InteractorFacade interactor)
         {
-            grabInteractableSetup?.Grab(interactor);
+            grabInteractableSetup.Grab(interactor);
         }
 
         /// <summary>
@@ -196,7 +196,7 @@
         /// <param name="interactor">The Interactor to ungrab from.</param>
         public virtual void Ungrab(InteractorFacade interactor)
         {
-            grabInteractableSetup?.Ungrab(interactor);
+            grabInteractableSetup.Ungrab(interactor);
         }
 
         /// <summary>
@@ -205,7 +205,7 @@
         /// <param name="sequenceIndex">The Interactor sequence index to ungrab from.</param>
         public virtual void Ungrab(int sequenceIndex = 0)
         {
-            grabInteractableSetup?.Ungrab(sequenceIndex);
+            grabInteractableSetup.Ungrab(sequenceIndex);
         }
 
         /// <summary>
@@ -213,8 +213,8 @@
         /// </summary>
         public virtual void RefreshInteractorRestrictions()
         {
-            touchInteractableSetup?.ConfigureTouchValidity();
-            grabInteractableSetup?.ConfigureGrabValidity();
+            touchInteractableSetup.ConfigureTouchValidity();
+            grabInteractableSetup.ConfigureGrabValidity();
         }
     }
 }

--- a/Prefabs/Interactions/Interactables/SharedResources/Scripts/TouchInteractableInternalSetup.cs
+++ b/Prefabs/Interactions/Interactables/SharedResources/Scripts/TouchInteractableInternalSetup.cs
@@ -40,7 +40,7 @@
         /// </summary>
         public virtual void ConfigureTouchValidity()
         {
-            if (facade?.disallowedTouchInteractors == null || touchValidity == null)
+            if (facade.disallowedTouchInteractors == null || touchValidity == null)
             {
                 return;
             }
@@ -62,11 +62,11 @@
             InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
-                if (facade?.TouchingInteractors.Count == 1)
+                if (facade.TouchingInteractors.Count == 1)
                 {
-                    facade?.FirstTouched?.Invoke(interactor);
+                    facade.FirstTouched?.Invoke(interactor);
                 }
-                facade?.Touched?.Invoke(interactor);
+                facade.Touched?.Invoke(interactor);
                 interactor.Touched?.Invoke(facade);
             }
         }
@@ -80,11 +80,11 @@
             InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
-                facade?.Untouched?.Invoke(interactor);
+                facade.Untouched?.Invoke(interactor);
                 interactor.Untouched?.Invoke(facade);
-                if (facade?.TouchingInteractors.Count == 0)
+                if (facade.TouchingInteractors.Count == 0)
                 {
-                    facade?.LastUntouched?.Invoke(interactor);
+                    facade.LastUntouched?.Invoke(interactor);
                 }
             }
         }

--- a/Prefabs/Interactions/Interactors/SharedResources/Scripts/GrabInteractorInternalSetup.cs
+++ b/Prefabs/Interactions/Interactors/SharedResources/Scripts/GrabInteractorInternalSetup.cs
@@ -80,7 +80,7 @@
             if (grabAction != null && facade != null && facade.GrabAction != null)
             {
                 grabAction.ClearSources();
-                grabAction.AddSource(facade?.GrabAction);
+                grabAction.AddSource(facade.GrabAction);
             }
         }
 
@@ -138,7 +138,7 @@
             }
 
             Ungrab();
-            startGrabbingPublisher?.SetActiveCollisions(CreateActiveCollisionsEventData(interactable.gameObject, collision, collider));
+            startGrabbingPublisher.SetActiveCollisions(CreateActiveCollisionsEventData(interactable.gameObject, collision, collider));
             ProcessGrabAction(startGrabbingPublisher, true);
             if (interactable.grabType == InteractableFacade.ActiveType.Toggle)
             {
@@ -166,13 +166,13 @@
 
         protected virtual void ProcessGrabAction(ActiveCollisionPublisher publisher, bool actionState)
         {
-            if (grabAction?.Value != actionState)
+            if (grabAction.Value != actionState)
             {
-                grabAction?.Receive(actionState);
+                grabAction.Receive(actionState);
             }
             else
             {
-                publisher?.Publish();
+                publisher.Publish();
             }
         }
 

--- a/Prefabs/Interactions/Interactors/SharedResources/Scripts/InteractorFacade.cs
+++ b/Prefabs/Interactions/Interactors/SharedResources/Scripts/InteractorFacade.cs
@@ -125,15 +125,15 @@
         /// <summary>
         /// A collection of currently touched GameObjects.
         /// </summary>
-        public List<GameObject> TouchedObjects => touchInteractorSetup?.TouchedObjects;
+        public List<GameObject> TouchedObjects => touchInteractorSetup.TouchedObjects;
         /// <summary>
         /// The currently active touched GameObject.
         /// </summary>
-        public GameObject ActiveTouchedObject => touchInteractorSetup?.ActiveTouchedObject;
+        public GameObject ActiveTouchedObject => touchInteractorSetup.ActiveTouchedObject;
         /// <summary>
         /// A collection of currently grabbed GameObjects.
         /// </summary>
-        public List<GameObject> GrabbedObjects => grabInteractorSetup?.GrabbedObjects;
+        public List<GameObject> GrabbedObjects => grabInteractorSetup.GrabbedObjects;
 
         /// <summary>
         /// Attempt to grab a <see cref="GameObject"/> that contains an Interactable to the current Interactor.
@@ -161,7 +161,7 @@
         /// <param name="collider">Custom collider data.</param>
         public virtual void Grab(InteractableFacade interactable, Collision collision, Collider collider)
         {
-            grabInteractorSetup?.Grab(interactable, collision, collider);
+            grabInteractorSetup.Grab(interactable, collision, collider);
         }
 
         /// <summary>
@@ -169,7 +169,7 @@
         /// </summary>
         public virtual void Ungrab()
         {
-            grabInteractorSetup?.Ungrab();
+            grabInteractorSetup.Ungrab();
         }
 
         protected virtual void OnValidate()

--- a/Prefabs/Interactions/Interactors/SharedResources/Scripts/TouchInteractorInternalSetup.cs
+++ b/Prefabs/Interactions/Interactors/SharedResources/Scripts/TouchInteractorInternalSetup.cs
@@ -59,12 +59,12 @@
         {
             if (startTouchingPublisher != null)
             {
-                startTouchingPublisher.payload.sourceContainer = facade?.gameObject;
+                startTouchingPublisher.payload.sourceContainer = facade.gameObject;
             }
 
             if (stopTouchingPublisher != null)
             {
-                stopTouchingPublisher.payload.sourceContainer = facade?.gameObject;
+                stopTouchingPublisher.payload.sourceContainer = facade.gameObject;
             }
         }
 

--- a/Prefabs/Locomotion/Teleporters/SharedResources/Scripts/TeleporterFacade.cs
+++ b/Prefabs/Locomotion/Teleporters/SharedResources/Scripts/TeleporterFacade.cs
@@ -60,7 +60,7 @@
         /// <param name="destination">The location to attempt to teleport to.</param>
         public virtual void Teleport(TransformData destination)
         {
-            internalSetup?.Teleport(destination);
+            internalSetup.Teleport(destination);
         }
     }
 }

--- a/Scripts/Tracking/Collision/Active/Operation/NotifierContainerExtractor.cs
+++ b/Scripts/Tracking/Collision/Active/Operation/NotifierContainerExtractor.cs
@@ -21,7 +21,7 @@
                 return null;
             }
 
-            Result = notifier.forwardSource?.gameObject;
+            Result = notifier.forwardSource.gameObject;
             return base.Extract();
         }
 

--- a/Scripts/Tracking/Follow/Modifier/FollowModifier.cs
+++ b/Scripts/Tracking/Follow/Modifier/FollowModifier.cs
@@ -73,9 +73,9 @@
 
             Premodified?.Invoke(eventData.Set(source, target, offset));
 
-            positionModifier?.Modify(source, target, offset);
-            rotationModifier?.Modify(source, target, offset);
-            scaleModifier?.Modify(source, target, offset);
+            positionModifier.Modify(source, target, offset);
+            rotationModifier.Modify(source, target, offset);
+            scaleModifier.Modify(source, target, offset);
 
             Modified?.Invoke(eventData.Set(source, target, offset));
         }

--- a/Scripts/Tracking/Follow/ObjectFollower.cs
+++ b/Scripts/Tracking/Follow/ObjectFollower.cs
@@ -161,10 +161,15 @@
         /// <inheritdoc />
         protected override void ProcessComponent(Component source, Component target)
         {
+            if (followModifier == null)
+            {
+                return;
+            }
+
             GameObject sourceGameObject = (modificationType == ModificationType.ModifyTargetUsingSource ? source.TryGetGameObject() : target.TryGetGameObject());
             GameObject targetGameObject = (modificationType == ModificationType.ModifyTargetUsingSource ? target.TryGetGameObject() : source.TryGetGameObject());
 
-            followModifier?.Modify(sourceGameObject, targetGameObject, followOffset);
+            followModifier.Modify(sourceGameObject, targetGameObject, followOffset);
         }
     }
 }


### PR DESCRIPTION
Monadic null checking was introduced in C#6 and means that objects
don't need an `if (x == null)` check and can simply do `x?.` to
determine if the object is null. However, as Unity bypasses the
standard operators and checks, this means the monadic null check
does not work with Unity MonoBehaviour scripts along with GameObject
and Transform objects so any use of `?.` will not produce the
expected results.

This fix removes any misuse of the monadic null check.