### PR TITLE
fix(Interactions): publish untouch when interactor is disabled

### DIFF
--- a/Prefabs/Interactions/Interactors/SharedResources/Scripts/TouchInteractorInternalSetup.cs
+++ b/Prefabs/Interactions/Interactors/SharedResources/Scripts/TouchInteractorInternalSetup.cs
@@ -73,6 +73,12 @@
             ConfigurePublishers();
         }
 
+        protected virtual void OnDisable()
+        {
+            stopTouchingPublisher.ForceSetActiveCollisions(startTouchingPublisher.payload);
+            stopTouchingPublisher.ForcePublish();
+        }
+
         /// <summary>
         /// Retreives a collection of currently touched GameObjects.
         /// </summary>

--- a/Scripts/Tracking/Collision/Active/ActiveCollisionPublisher.cs
+++ b/Scripts/Tracking/Collision/Active/ActiveCollisionPublisher.cs
@@ -78,12 +78,26 @@
         }
 
         /// <summary>
-        /// Sets the active collision data by copying it from given <see cref="PayloadData"/>.
+        /// Sets the active collision data by copying it from given <see cref="PayloadData"/> as long as the component is active and enabled.
         /// </summary>
         /// <param name="payload">The data to copy from.</param>
         public virtual void SetActiveCollisions(PayloadData payload)
         {
-            if (payload == null || !isActiveAndEnabled)
+            if (!isActiveAndEnabled)
+            {
+                return;
+            }
+
+            ForceSetActiveCollisions(payload);
+        }
+
+        /// <summary>
+        /// Sets the active collision data by copying it from given <see cref="PayloadData"/>.
+        /// </summary>
+        /// <param name="payload">The data to copy from.</param>
+        public virtual void ForceSetActiveCollisions(PayloadData payload)
+        {
+            if (payload == null)
             {
                 return;
             }
@@ -93,7 +107,7 @@
         }
 
         /// <summary>
-        /// Publishes itself and the current collision to all <see cref="ActiveCollisionConsumer"/> components found on any of the active collisions.
+        /// Publishes itself and the current collision to all <see cref="ActiveCollisionConsumer"/> components found on any of the active collisions as long as the component is active and enabled.
         /// </summary>
         public virtual void Publish()
         {
@@ -101,6 +115,15 @@
             {
                 return;
             }
+
+            ForcePublish();
+        }
+
+        /// <summary>
+        /// Publishes itself and the current collision to all <see cref="ActiveCollisionConsumer"/> components found on any of the active collisions as long as the component.
+        /// </summary>
+        public virtual void ForcePublish()
+        {
             payload.PublisherContainer = gameObject;
             foreach (CollisionNotifier.EventData currentCollision in payload.ActiveCollisions)
             {


### PR DESCRIPTION
The Untouch event on an Interactor was not being emitted when the
Interactor became disabled due to the collider not actually calling
the Collision/Trigger exit code.

The solution is to copy the current touching objects to the stop
touching collision list and force publish it to tell any existing
touched item that it is no longer being touched.

To achieve the publish, a new Force method has been added as the
normal methods only operate when the Interactor is active and enabled
and it will not execute those methods in OnDisable.