### PR TITLE
fix(Structure): alternative null checks for removed monadic checks

### DIFF
--- a/Prefabs/Locomotion/Teleporters/SharedResources/Scripts/TeleporterInternalSetup.cs
+++ b/Prefabs/Locomotion/Teleporters/SharedResources/Scripts/TeleporterInternalSetup.cs
@@ -108,7 +108,7 @@
         /// <param name="data">The location data.</param>
         public virtual void NotifyTeleporting(TransformPropertyApplier.EventData data)
         {
-            facade?.Teleporting.Invoke(data);
+            facade.Teleporting?.Invoke(data);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@
         /// <param name="data">The location data.</param>
         public virtual void NotifyTeleported(TransformPropertyApplier.EventData data)
         {
-            facade?.Teleported.Invoke(data);
+            facade.Teleported?.Invoke(data);
         }
 
         /// <summary>

--- a/Scripts/Tracking/Collision/Active/Operation/NotifierContainerExtractor.cs
+++ b/Scripts/Tracking/Collision/Active/Operation/NotifierContainerExtractor.cs
@@ -15,7 +15,7 @@
         /// <returns>The forward source container within the notifier.</returns>
         public virtual GameObject Extract(CollisionNotifier.EventData notifier)
         {
-            if (notifier == null)
+            if (notifier == null || notifier.forwardSource == null)
             {
                 Result = null;
                 return null;

--- a/Scripts/Tracking/Follow/Modifier/FollowModifier.cs
+++ b/Scripts/Tracking/Follow/Modifier/FollowModifier.cs
@@ -73,9 +73,18 @@
 
             Premodified?.Invoke(eventData.Set(source, target, offset));
 
-            positionModifier.Modify(source, target, offset);
-            rotationModifier.Modify(source, target, offset);
-            scaleModifier.Modify(source, target, offset);
+            if (positionModifier != null)
+            {
+                positionModifier.Modify(source, target, offset);
+            }
+            if (rotationModifier != null)
+            {
+                rotationModifier.Modify(source, target, offset);
+            }
+            if (scaleModifier != null)
+            {
+                scaleModifier.Modify(source, target, offset);
+            }
 
             Modified?.Invoke(eventData.Set(source, target, offset));
         }


### PR DESCRIPTION
Since the monadic null checks were removed, a number of scripts would
fail due to null data trying to be processed. These have now been
fixed with an explicit `x == null` check.