### PR TITLE
feat(Velocity): calculate with optional relative to object - fixes #197

### DIFF
--- a/Prefabs/CameraRig/SimulatedCameraRig/[SimulatedCameraRig].prefab
+++ b/Prefabs/CameraRig/SimulatedCameraRig/[SimulatedCameraRig].prefab
@@ -2399,6 +2399,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   source: {fileID: 1581495199198194}
+  relativeTo: {fileID: 1121419207030402}
   autoStartSampling: 1
   velocityAverageFrames: 5
   angularVelocityAverageFrames: 10
@@ -2593,6 +2594,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   source: {fileID: 1496419616007624}
+  relativeTo: {fileID: 0}
   autoStartSampling: 1
   velocityAverageFrames: 5
   angularVelocityAverageFrames: 10
@@ -2743,9 +2745,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 37939f2e3f9c118469597addd953b38c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  trackedAlias: {fileID: 0}
   disableXRSettings: 1
   simulatedFrameRate: 90
-  trackedAlias: {fileID: 0}
   playareaPosition: {fileID: 114447943956170304}
   playareaResetter: {fileID: 114041395006009992}
 --- !u!114 &114351927556944560
@@ -3202,6 +3204,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   source: {fileID: 1643489474284420}
+  relativeTo: {fileID: 1121419207030402}
   autoStartSampling: 1
   velocityAverageFrames: 5
   angularVelocityAverageFrames: 10

--- a/Prefabs/CameraRig/UnityXRCameraRig/[UnityXRCameraRig].prefab
+++ b/Prefabs/CameraRig/UnityXRCameraRig/[UnityXRCameraRig].prefab
@@ -207,6 +207,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   source: {fileID: 1085192622640384}
+  relativeTo: {fileID: 1467290445770872}
   autoStartSampling: 1
   velocityAverageFrames: 5
   angularVelocityAverageFrames: 10
@@ -222,6 +223,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   source: {fileID: 1907295252762062}
+  relativeTo: {fileID: 0}
   autoStartSampling: 1
   velocityAverageFrames: 5
   angularVelocityAverageFrames: 10
@@ -266,6 +268,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   source: {fileID: 1056323152614116}
+  relativeTo: {fileID: 1467290445770872}
   autoStartSampling: 1
   velocityAverageFrames: 5
   angularVelocityAverageFrames: 10

--- a/Scripts/Extension/GameObjectExtensions.cs
+++ b/Scripts/Extension/GameObjectExtensions.cs
@@ -48,5 +48,49 @@
 
             return foundComponent;
         }
+
+        /// <summary>
+        /// Attempts to retrieve the position of the <see cref="GameObject.transform"/>.
+        /// </summary>
+        /// <param name="gameObject">The reference <see cref="GameObject"/> to retrieve for.</param>
+        /// <param name="getLocal">Determines whether to get the local or world position.</param>
+        /// <returns>The position of the <see cref="GameObject.transform"/>.</returns>
+        public static Vector3 TryGetPosition(this GameObject gameObject, bool getLocal = false)
+        {
+            return (gameObject != null ? (getLocal ? gameObject.transform.localPosition : gameObject.transform.position) : Vector3.zero);
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the rotation of the <see cref="GameObject.transform"/>.
+        /// </summary>
+        /// <param name="gameObject">The reference <see cref="GameObject"/> to retrieve for.</param>
+        /// <param name="getLocal">Determines whether to get the local or world rotation.</param>
+        /// <returns>The rotation of the <see cref="GameObject.transform"/>.</returns>
+        public static Quaternion TryGetRotation(this GameObject gameObject, bool getLocal = false)
+        {
+            return (gameObject != null ? (getLocal ? gameObject.transform.localRotation : gameObject.transform.rotation) : Quaternion.identity);
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the euler rotation of the <see cref="GameObject.transform"/>.
+        /// </summary>
+        /// <param name="gameObject">The reference <see cref="GameObject"/> to retrieve for.</param>
+        /// <param name="getLocal">Determines whether to get the local or world euler rotation.</param>
+        /// <returns>The euler rotation of the <see cref="GameObject.transform"/>.</returns>
+        public static Vector3 TryGetEulerRotation(this GameObject gameObject, bool getLocal = false)
+        {
+            return (gameObject != null ? (getLocal ? gameObject.transform.localEulerAngles : gameObject.transform.eulerAngles) : Vector3.zero);
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the scale of the <see cref="GameObject.transform"/>.
+        /// </summary>
+        /// <param name="gameObject">The reference <see cref="GameObject"/> to retrieve for.</param>
+        /// <param name="getLocal">Determines whether to get the local or world scale.</param>
+        /// <returns>The scale of the <see cref="GameObject.transform"/>.</returns>
+        public static Vector3 TryGetScale(this GameObject gameObject, bool getLocal = false)
+        {
+            return (gameObject != null ? (getLocal ? gameObject.transform.localScale : gameObject.transform.lossyScale) : Vector3.zero);
+        }
     }
 }

--- a/Tests/Editor/Extension/GameObjectExtensionsTest.cs
+++ b/Tests/Editor/Extension/GameObjectExtensionsTest.cs
@@ -155,5 +155,117 @@ namespace Test.VRTK.Core.Extension
             Object.DestroyImmediate(child);
             Object.DestroyImmediate(parent);
         }
+
+        [Test]
+        public void TryGetPosition()
+        {
+            Vector3 destinationPosition = Vector3.one * 2f;
+            GameObject parent = new GameObject();
+            parent.transform.position = destinationPosition;
+
+            Assert.AreEqual(destinationPosition, parent.TryGetPosition());
+
+            Object.DestroyImmediate(parent);
+        }
+
+        [Test]
+        public void TryGetPositionLocal()
+        {
+            Vector3 destinationPosition = Vector3.one * 2f;
+            GameObject parent = new GameObject();
+            GameObject child = new GameObject();
+            child.transform.SetParent(parent.transform);
+            child.transform.position = destinationPosition;
+            parent.transform.position = destinationPosition * 2f;
+
+            Assert.AreEqual(destinationPosition, child.TryGetPosition(true));
+
+            Object.DestroyImmediate(parent);
+            Object.DestroyImmediate(child);
+        }
+
+        [Test]
+        public void TryGetRotation()
+        {
+            Quaternion destinationRotation = Quaternion.Euler(Vector3.up * 90f);
+            GameObject parent = new GameObject();
+            parent.transform.rotation = destinationRotation;
+
+            Assert.AreEqual(destinationRotation.ToString(), parent.TryGetRotation().ToString());
+
+            Object.DestroyImmediate(parent);
+        }
+
+        [Test]
+        public void TryGetRotationLocal()
+        {
+            Quaternion destinationRotation = Quaternion.Euler(Vector3.up * 90f);
+            GameObject parent = new GameObject();
+            GameObject child = new GameObject();
+            child.transform.SetParent(parent.transform);
+            child.transform.localRotation = destinationRotation;
+            parent.transform.localRotation = Quaternion.Euler(Vector3.up * 145f);
+
+            Assert.AreEqual(destinationRotation.ToString(), child.TryGetRotation(true).ToString());
+
+            Object.DestroyImmediate(parent);
+            Object.DestroyImmediate(child);
+        }
+
+        [Test]
+        public void TryGetEulerRotation()
+        {
+            Vector3 destinationEulerRotation = Vector3.up * 90f;
+            GameObject parent = new GameObject();
+            parent.transform.eulerAngles = destinationEulerRotation;
+
+            Assert.AreEqual(destinationEulerRotation, parent.TryGetEulerRotation());
+
+            Object.DestroyImmediate(parent);
+        }
+
+        [Test]
+        public void TryGetEulerRotationLocal()
+        {
+            Vector3 destinationRotation = Vector3.up * 90f;
+            GameObject parent = new GameObject();
+            GameObject child = new GameObject();
+            child.transform.SetParent(parent.transform);
+            child.transform.localEulerAngles = destinationRotation;
+            parent.transform.localEulerAngles = Vector3.up * 145f;
+
+            Assert.AreEqual(destinationRotation.ToString(), child.TryGetEulerRotation(true).ToString());
+
+            Object.DestroyImmediate(parent);
+            Object.DestroyImmediate(child);
+        }
+
+        [Test]
+        public void TryGetScale()
+        {
+            Vector3 destinationScale = Vector3.one * 2f;
+            GameObject parent = new GameObject();
+            parent.transform.SetGlobalScale(destinationScale);
+
+            Assert.AreEqual(destinationScale, parent.TryGetScale());
+
+            Object.DestroyImmediate(parent);
+        }
+
+        [Test]
+        public void TryGetScaleLocal()
+        {
+            Vector3 destinationScale = Vector3.one * 2f;
+            GameObject parent = new GameObject();
+            GameObject child = new GameObject();
+            child.transform.SetParent(parent.transform);
+            child.transform.localScale = destinationScale;
+            parent.transform.SetGlobalScale(destinationScale * 2f);
+
+            Assert.AreEqual(destinationScale, child.TryGetScale(true));
+
+            Object.DestroyImmediate(parent);
+            Object.DestroyImmediate(child);
+        }
     }
 }


### PR DESCRIPTION
The VelocityEstimator now allows for a relativeTo GameObject that
can be used to determine a relative velocity rather than a global
velocity.

This is useful if the tracked object is also being moved due to
a parent object being moved.

The CameraRig prefabs have been updated so the controller velocity
is always tracked relative to the parent play area.