### PR TITLE
feat(Locomotion): allow teleport offset to be optional - resolves #207

### DIFF
--- a/Prefabs/Locomotion/Teleporters/SharedResources/Scripts/TeleporterFacade.cs
+++ b/Prefabs/Locomotion/Teleporters/SharedResources/Scripts/TeleporterFacade.cs
@@ -13,15 +13,20 @@
     {
         #region Teleporter Settings
         /// <summary>
-        /// The alias for the CameraRig Play Area.
+        /// The target to move to the teleported position.
         /// </summary>
-        [Header("Teleporter Settings"), Tooltip("The alias for the CameraRig Play Area.")]
-        public GameObject playAreaAlias;
+        [Header("Teleporter Settings"), Tooltip("The target to move to the teleported position.")]
+        public GameObject target;
         /// <summary>
-        /// The alias for the CameraRig Headset.
+        /// The offset to compensate the teleported target position by for both floor snapping and position movement.
         /// </summary>
-        [Tooltip("The alias for the CameraRig Headset.")]
-        public GameObject headsetAlias;
+        [Tooltip("The offset to compensate the teleported target position by for both floor snapping and position movement.")]
+        public GameObject offset;
+        /// <summary>
+        /// Determines if only the floor snap should only be compensated by the <see cref="offset"/> or whether the teleported target position should also be compensated by the <see cref="offset"/>.
+        /// </summary>
+        [Tooltip("Determines if only the floor snap should only be compensated by the offset or whether the teleported target position should also be compensated by the offset.")]
+        public bool onlyOffsetFloorSnap;
         /// <summary>
         /// The <see cref="CameraList"/> of scene <see cref="Camera"/>s to apply a fade to.
         /// </summary>

--- a/Prefabs/Locomotion/Teleporters/Teleporter.Dash.SnapToFloor.prefab
+++ b/Prefabs/Locomotion/Teleporters/Teleporter.Dash.SnapToFloor.prefab
@@ -498,6 +498,7 @@ MonoBehaviour:
   process:
     field: {fileID: 114833483784811346}
   onlyProcessOnActiveAndEnabled: 1
+  utilization: 1
 --- !u!114 &114973425399694208
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -520,6 +521,8 @@ MonoBehaviour:
   transformPropertyApplierAliases:
   - {fileID: 114595092254332754}
   - {fileID: 114898619257496582}
+  transformPropertyApplierIgnoreOffsetAliases:
+  - {fileID: 114898619257496582}
   cameraColorOverlays:
   - {fileID: 114308937317668468}
 --- !u!114 &114979836843907558
@@ -533,8 +536,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a11803ae5247db04b8ba76bdf0e5c67d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playAreaAlias: {fileID: 0}
-  headsetAlias: {fileID: 0}
+  target: {fileID: 0}
+  offset: {fileID: 0}
+  onlyOffsetFloorSnap: 0
   sceneCameras: {fileID: 0}
   targetValidity:
     field: {fileID: 0}

--- a/Prefabs/Locomotion/Teleporters/Teleporter.Instant.SnapToFloor.prefab
+++ b/Prefabs/Locomotion/Teleporters/Teleporter.Instant.SnapToFloor.prefab
@@ -310,6 +310,7 @@ MonoBehaviour:
   process:
     field: {fileID: 114302476225177798}
   onlyProcessOnActiveAndEnabled: 1
+  utilization: 1
 --- !u!114 &114389553745756508
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -429,6 +430,8 @@ MonoBehaviour:
   transformPropertyApplierAliases:
   - {fileID: 114228719762159142}
   - {fileID: 114389553745756508}
+  transformPropertyApplierIgnoreOffsetAliases:
+  - {fileID: 114389553745756508}
   cameraColorOverlays:
   - {fileID: 114895205429108944}
 --- !u!114 &114671045609980380
@@ -498,8 +501,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a11803ae5247db04b8ba76bdf0e5c67d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playAreaAlias: {fileID: 0}
-  headsetAlias: {fileID: 0}
+  target: {fileID: 0}
+  offset: {fileID: 0}
+  onlyOffsetFloorSnap: 0
   sceneCameras: {fileID: 0}
   targetValidity:
     field: {fileID: 0}


### PR DESCRIPTION
The Teleporter would previously always apply an offset of the
HeadsetAlias to the PlayAreaAlias when moving it but there can be
instances where the PlayAreaAlias centre is wanted to be moved to
the teleport point.

This is now possible by optionally setting the Offset parameter
on the TransformPropertyApplier inside the HeightAdjustTeleporter
GameObject.

The parameter fields have also changed to be more generic.

PlayAreaAlias becomes Target
HeadsetAlias becomes Offset

And a new bool, of `OnlyOffsetFloorSnap` allows for the offset
on teleport to be optional. If the setting is true then the Offset
is only applied when doing floor snapping, which has to always be
applied and cannot be optional.