### PR TITLE
refactor(Transformation): convert multipliers to be aggregators - fixes #217

### DIFF
--- a/Prefabs/CameraRig/PlayAreaRepresentation/PlayAreaRepresentation.prefab
+++ b/Prefabs/CameraRig/PlayAreaRepresentation/PlayAreaRepresentation.prefab
@@ -361,7 +361,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114381695561373098}
-        m_MethodName: SetIndex
+        m_MethodName: set_CurrentIndex
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -372,7 +372,7 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 114381695561373098}
-        m_MethodName: DoTransform
+        m_MethodName: SetElement
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -556,7 +556,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114381695561373098}
-        m_MethodName: SetIndex
+        m_MethodName: set_CurrentIndex
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Prefabs/CameraRig/SimulatedCameraRig/SharedResources/Scripts/ActiveObjectInternalSetup.cs
+++ b/Prefabs/CameraRig/SimulatedCameraRig/SharedResources/Scripts/ActiveObjectInternalSetup.cs
@@ -51,12 +51,14 @@
 
             foreach (FloatMultiplier positiveMultiplier in positiveMultipliers)
             {
-                positiveMultiplier.SetMultiplier(movementSpeed);
+                positiveMultiplier.SetElement(1, movementSpeed);
+                positiveMultiplier.CurrentIndex = 0;
             }
 
             foreach (FloatMultiplier negativeMultiplier in negativeMultipliers)
             {
-                negativeMultiplier.SetMultiplier(-movementSpeed);
+                negativeMultiplier.SetElement(1, -movementSpeed);
+                negativeMultiplier.CurrentIndex = 0;
             }
         }
     }

--- a/Prefabs/CameraRig/SimulatedCameraRig/[SimulatedCameraRig].prefab
+++ b/Prefabs/CameraRig/SimulatedCameraRig/[SimulatedCameraRig].prefab
@@ -2643,7 +2643,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114351927556944560}
-        m_MethodName: SetIndex
+        m_MethodName: set_CurrentIndex
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2666,7 +2666,9 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Data.Type.Transformation.FloatMultiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  multiplier: -0.025
+  collection:
+  - 0
+  - -0.025
 --- !u!114 &114321207147230336
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2941,7 +2943,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114351927556944560}
-        m_MethodName: SetIndex
+        m_MethodName: set_CurrentIndex
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2964,7 +2966,9 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Data.Type.Transformation.FloatMultiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  multiplier: 0.025
+  collection:
+  - 0
+  - 0.025
 --- !u!114 &114515770342330834
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -3129,7 +3133,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114154633549528858}
-        m_MethodName: SetIndex
+        m_MethodName: set_CurrentIndex
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3152,7 +3156,9 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Data.Type.Transformation.FloatMultiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  multiplier: 0.025
+  collection:
+  - 0
+  - 0.025
 --- !u!114 &114697227851310196
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -3386,7 +3392,9 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Data.Type.Transformation.Vector2Multiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  multiplier: {x: 1, y: -1}
+  collection:
+  - {x: 0, y: 0}
+  - {x: 1, y: -1}
 --- !u!114 &114886786870708734
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -3588,7 +3596,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114154633549528858}
-        m_MethodName: SetIndex
+        m_MethodName: set_CurrentIndex
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3611,7 +3619,9 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Data.Type.Transformation.FloatMultiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  multiplier: -0.025
+  collection:
+  - 0
+  - -0.025
 --- !u!114 &114918917931712692
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Prefabs/Interactions/Interactables/Interactable.Climbable.prefab
+++ b/Prefabs/Interactions/Interactables/Interactable.Climbable.prefab
@@ -2674,7 +2674,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   climbFacade: {fileID: 0}
-  releaseMultiplier: {x: -10, y: -10, z: -10}
+  releaseMultiplier: {x: -1.5, y: -1.5, z: -1.5}
   internalSetup: {fileID: 114105533547169964}
 --- !u!114 &114621324980172646
 MonoBehaviour:

--- a/Prefabs/Locomotion/Movement/AxesToVector3/AxesToVector3.prefab
+++ b/Prefabs/Locomotion/Movement/AxesToVector3/AxesToVector3.prefab
@@ -311,7 +311,9 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: VRTK.Core.Data.Type.Transformation.Vector3Multiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  multiplier: {x: 1, y: 0, z: 1}
+  collection:
+  - {x: 0, y: 0, z: 0}
+  - {x: 1, y: 0, z: 1}
 --- !u!114 &114133002543274014
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -459,7 +461,9 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: VRTK.Core.Data.Type.Transformation.Vector3Multiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  multiplier: {x: 1, y: 0, z: 1}
+  collection:
+  - {x: 0, y: 0, z: 0}
+  - {x: 1, y: 0, z: 1}
 --- !u!114 &114977719549242216
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Prefabs/Locomotion/Movement/AxesToVector3/SharedResources/Scripts/AxesToVector3InternalSetup.cs
+++ b/Prefabs/Locomotion/Movement/AxesToVector3/SharedResources/Scripts/AxesToVector3InternalSetup.cs
@@ -75,8 +75,9 @@
         /// </summary>
         public virtual void SetMultipliers()
         {
-            speedMultiplier.SetXMultiplier(facade.LateralSpeedMultiplier);
-            speedMultiplier.SetZMultiplier(facade.LongitudinalSpeedMultiplier);
+            speedMultiplier.SetElementX(1, facade.LateralSpeedMultiplier);
+            speedMultiplier.SetElementZ(1, facade.LongitudinalSpeedMultiplier);
+            speedMultiplier.CurrentIndex = 0;
         }
 
         /// <summary>

--- a/Prefabs/Locomotion/Movement/Climb/Climb.prefab
+++ b/Prefabs/Locomotion/Movement/Climb/Climb.prefab
@@ -521,7 +521,9 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: VRTK.Core.Data.Type.Transformation.Vector3Multiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  multiplier: {x: 1, y: 1, z: 1}
+  collection:
+  - {x: 0, y: 0, z: 0}
+  - {x: 1, y: 1, z: 1}
 --- !u!114 &114276270614342360
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -649,7 +651,9 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: VRTK.Core.Data.Type.Transformation.Vector3Multiplier+UnityEvent, Assembly-CSharp,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  multiplier: {x: -1, y: -1, z: -1}
+  collection:
+  - {x: 0, y: 0, z: 0}
+  - {x: -1, y: -1, z: -1}
 --- !u!114 &114849865521691880
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Prefabs/Locomotion/Movement/Climb/SharedResources/Scripts/ClimbFacade.cs
+++ b/Prefabs/Locomotion/Movement/Climb/SharedResources/Scripts/ClimbFacade.cs
@@ -161,7 +161,8 @@
         /// <param name="multiplier">The multiplier to apply to tracked velocity.</param>
         public virtual void SetVelocityMultiplier(Vector3 multiplier)
         {
-            internalSetup.velocityMultiplier.SetMultiplier(multiplier);
+            internalSetup.velocityMultiplier.SetElement(1, multiplier);
+            internalSetup.velocityMultiplier.CurrentIndex = 0;
         }
     }
 }

--- a/Scripts/Data/Type/Transformation/CollectionAggregator.cs
+++ b/Scripts/Data/Type/Transformation/CollectionAggregator.cs
@@ -24,38 +24,28 @@
         /// </summary>
         public int CurrentIndex
         {
-            get;
-            protected set;
+            get { return _currentIndex; }
+            set { _currentIndex = PreprocessCurrentIndex(value); }
         }
+        private int _currentIndex;
 
         /// <summary>
-        /// Sets the collection index that will store a given input value. The given index will be clamped to the range of valid indexes.
-        /// </summary>
-        /// <param name="index">The index to set the collection value at.</param>
-        public virtual void SetIndex(int index)
-        {
-            index = (index >= 0 ? index : collection.Count + index);
-            CurrentIndex = Mathf.Clamp(index, 0, collection.Count - 1);
-        }
-
-        /// <summary>
-        /// Updates the current collection index value with the given <see cref="TInput"/>.
+        /// Updates the collection at the <see cref="CurrentIndex"/> with the given <see cref="TInput"/>.
         /// </summary>
         /// <param name="input">The element to update the collection with.</param>
-        public virtual void SetElementAtCurrentIndex(TInput input)
+        public virtual void SetElement(TInput input)
         {
             collection[CurrentIndex] = input;
         }
 
         /// <summary>
-        /// Updates the element at the given index.
+        /// Updates the element at the given index without updating the collection <see cref="CurrentIndex"/>.
         /// </summary>
         /// <param name="index">The index in the collection to update at.</param>
         /// <param name="input">The element to update the collection with.</param>
         public virtual void SetElement(int index, TInput input)
         {
-            SetIndex(index);
-            SetElementAtCurrentIndex(input);
+            collection[WrapAroundAndClamp(index)] = input;
         }
 
         /// <summary>
@@ -66,7 +56,7 @@
         /// <returns>The summed value of all values in the collection.</returns>
         public virtual TOutput Transform(int index, TInput input)
         {
-            SetIndex(index);
+            CurrentIndex = index;
             return Transform(input);
         }
 
@@ -87,7 +77,7 @@
         protected abstract TOutput ProcessCollection();
 
         /// <summary>
-        /// Processes the given input by adding it to the collection at the saved current index.
+        /// Processes the given input by adding it to the collection at the <see cref="CurrentIndex"/>.
         /// </summary>
         /// <param name="input">The value to add to the collection.</param>
         /// <returns>The summed value of all values in the collection.</returns>
@@ -98,8 +88,29 @@
                 return default(TOutput);
             }
 
-            SetElementAtCurrentIndex(input);
+            SetElement(input);
             return ProcessCollection();
+        }
+
+        /// <summary>
+        /// Preprocesses the value to be set in <see cref="CurrentIndex"/>
+        /// </summary>
+        /// <param name="value">The value to process.</param>
+        /// <returns>The processed value</returns>
+        protected virtual int PreprocessCurrentIndex(int value)
+        {
+            return WrapAroundAndClamp(value);
+        }
+
+        /// <summary>
+        /// Wraps around and clamps the given value to within a valid range of the collection size.
+        /// </summary>
+        /// <param name="value">The value to process.</param>
+        /// <returns>The processed value.</returns>
+        protected virtual int WrapAroundAndClamp(int value)
+        {
+            value = (value >= 0 ? value : collection.Count + value);
+            return Mathf.Clamp(value, 0, collection.Count - 1);
         }
     }
 }

--- a/Scripts/Data/Type/Transformation/FloatMultiplier.cs
+++ b/Scripts/Data/Type/Transformation/FloatMultiplier.cs
@@ -1,16 +1,16 @@
 ﻿namespace VRTK.Core.Data.Type.Transformation
 {
-    using UnityEngine;
     using UnityEngine.Events;
     using System;
+    using System.Linq;
 
     /// <summary>
-    /// Transforms a float by multiplying it by a given multiplier.
+    /// Multiplies a collection of <see cref="float"/>s by multiplying each one to the next entry in the collection.
     /// </summary>
     /// <example>
-    /// 2f * 2f = 4f
+    /// 2f * 2f * 2f = 8f
     /// </example>
-    public class FloatMultiplier : Transformer<float, float, FloatMultiplier.UnityEvent>
+    public class FloatMultiplier : CollectionAggregator<float, float, FloatMultiplier.UnityEvent>
     {
         /// <summary>
         /// Defines the event with the multiplied <see cref="float"/> value.
@@ -20,29 +20,21 @@
         {
         }
 
-        /// <summary>
-        /// The value to multiply the input by.
-        /// </summary>
-        [Tooltip("The value to multiply the input by."), SerializeField]
-        protected float multiplier;
-
-        /// <summary>
-        /// Sets the value to multiply the input by.
-        /// </summary>
-        /// <param name="multiplier">The new multiplier value.</param>
-        public virtual void SetMultiplier(float multiplier)
+        /// <inheritdoc />
+        protected override float ProcessCollection()
         {
-            this.multiplier = multiplier;
+            return collection.Aggregate(Multiply);
         }
 
         /// <summary>
-        /// Multiplies the input by the multiplier.
+        /// Multiplies two <see cref="float"/> values.
         /// </summary>
-        /// <param name="input">The value to transform.</param>
-        /// <returns>The transformed value.</returns>
-        protected override float Process(float input)
+        /// <param name="multiplicand">The value to be multiplied.</param>
+        /// <param name="multiplier">The value to multiply with.</param>
+        /// <returns>The calculated value.</returns>
+        protected virtual float Multiply(float multiplicand, float multiplier)
         {
-            return (input * multiplier);
+            return multiplicand * multiplier;
         }
     }
 }

--- a/Scripts/Data/Type/Transformation/Vector2Multiplier.cs
+++ b/Scripts/Data/Type/Transformation/Vector2Multiplier.cs
@@ -3,14 +3,15 @@
     using UnityEngine;
     using UnityEngine.Events;
     using System;
+    using System.Linq;
 
     /// <summary>
-    /// Transforms a Vector2 by multiplying each coordinate by a given multiplier.
+    /// Multiplies a collection of <see cref="Vector2"/>s by multiplying each one to the next entry in the collection.
     /// </summary>
     /// <example>
     /// (2f,3f) * [3f,4f] = (6f,12f)
     /// </example>
-    public class Vector2Multiplier : Transformer<Vector2, Vector2, Vector2Multiplier.UnityEvent>
+    public class Vector2Multiplier : CollectionAggregator<Vector2, Vector2, Vector2Multiplier.UnityEvent>
     {
         /// <summary>
         /// Defines the event with the multiplied <see cref="Vector2"/> value.
@@ -21,46 +22,68 @@
         }
 
         /// <summary>
-        /// The value to multiply the input by.
+        /// Sets the x value of the <see cref="CurrentIndex"/> element.
         /// </summary>
-        [Tooltip("The value to multiply the input by."), SerializeField]
-        protected Vector2 multiplier = Vector2.one;
-
-        /// <summary>
-        /// Sets the value to multiply the input by.
-        /// </summary>
-        /// <param name="multiplier">The new multiplier value.</param>
-        public virtual void SetMultiplier(Vector2 multiplier)
+        /// <param name="value">The new x value.</param>
+        public virtual void SetElementX(float value)
         {
-            this.multiplier = multiplier;
+            Vector2 currentValue = collection[CurrentIndex];
+            currentValue.x = value;
+            collection[CurrentIndex] = currentValue;
         }
 
         /// <summary>
-        /// Sets the x value to multiply the input x by.
+        /// Sets the x value of the given index element.
         /// </summary>
-        /// <param name="xMultiplier">The new x multiplier value.</param>
-        public virtual void SetXMultiplier(float xMultiplier)
+        /// <param name="index">The index in the collection to update at.</param>
+        /// <param name="value">The new x value.</param>
+        public virtual void SetElementX(int index, float value)
         {
-            multiplier.x = xMultiplier;
+            index = WrapAroundAndClamp(index);
+            Vector2 currentValue = collection[index];
+            currentValue.x = value;
+            collection[index] = currentValue;
         }
 
         /// <summary>
-        /// Sets the y value to multiply the input y by.
+        /// Sets the y value of the <see cref="CurrentIndex"/> element.
         /// </summary>
-        /// <param name="yMultiplier">The new y multiplier value.</param>
-        public virtual void SetYMultiplier(float yMultiplier)
+        /// <param name="value">The new y value.</param>
+        public virtual void SetElementY(float value)
         {
-            multiplier.y = yMultiplier;
+            Vector2 currentValue = collection[CurrentIndex];
+            currentValue.y = value;
+            collection[CurrentIndex] = currentValue;
         }
 
         /// <summary>
-        /// Multiplies the input by the multipliers.
+        /// Sets the y value of the given index element.
         /// </summary>
-        /// <param name="input">The value to transform.</param>
-        /// <returns>The transformed value.</returns>
-        protected override Vector2 Process(Vector2 input)
+        /// <param name="index">The index in the collection to update at.</param>
+        /// <param name="value">The new y value.</param>
+        public virtual void SetElementY(int index, float value)
         {
-            return Vector2.Scale(input, multiplier);
+            index = WrapAroundAndClamp(index);
+            Vector2 currentValue = collection[index];
+            currentValue.y = value;
+            collection[index] = currentValue;
+        }
+
+        /// <inheritdoc />
+        protected override Vector2 ProcessCollection()
+        {
+            return collection.Aggregate(Multiply);
+        }
+
+        /// <summary>
+        /// Multiplies two <see cref="Vector2"/> values.
+        /// </summary>
+        /// <param name="multiplicand">The value to be multiplied.</param>
+        /// <param name="multiplier">The value to multiply with.</param>
+        /// <returns>The calculated value.</returns>
+        protected virtual Vector2 Multiply(Vector2 multiplicand, Vector2 multiplier)
+        {
+            return Vector2.Scale(multiplicand, multiplier);
         }
     }
 }

--- a/Scripts/Data/Type/Transformation/Vector3Multiplier.cs
+++ b/Scripts/Data/Type/Transformation/Vector3Multiplier.cs
@@ -3,14 +3,15 @@
     using UnityEngine;
     using UnityEngine.Events;
     using System;
+    using System.Linq;
 
     /// <summary>
-    /// Transforms a <see cref="Vector3"/> by multiplying each coordinate by a given multiplier.
+    /// Multiplies a collection of <see cref="Vector3"/>s by multiplying each one to the next entry in the collection.
     /// </summary>
     /// <example>
     /// (2f,3f,4f) * [3f,4f,5f] = (6f,12f,20f)
     /// </example>
-    public class Vector3Multiplier : Transformer<Vector3, Vector3, Vector3Multiplier.UnityEvent>
+    public class Vector3Multiplier : CollectionAggregator<Vector3, Vector3, Vector3Multiplier.UnityEvent>
     {
         /// <summary>
         /// Defines the event with the multiplied <see cref="Vector3"/> value.
@@ -21,55 +22,92 @@
         }
 
         /// <summary>
-        /// The value to multiply the input by.
+        /// Sets the x value of the <see cref="CurrentIndex"/> element.
         /// </summary>
-        [Tooltip("The value to multiply the input by."), SerializeField]
-        protected Vector3 multiplier = Vector3.one;
-
-        /// <summary>
-        /// Sets the value to multiply the input by.
-        /// </summary>
-        /// <param name="multiplier">The new multiplier value.</param>
-        public virtual void SetMultiplier(Vector3 multiplier)
+        /// <param name="value">The new x value.</param>
+        public virtual void SetElementX(float value)
         {
-            this.multiplier = multiplier;
+            Vector3 currentValue = collection[CurrentIndex];
+            currentValue.x = value;
+            collection[CurrentIndex] = currentValue;
         }
 
         /// <summary>
-        /// Sets the x value to multiply the input x by.
+        /// Sets the x value of the given index element.
         /// </summary>
-        /// <param name="xMultiplier">The new x multiplier value.</param>
-        public virtual void SetXMultiplier(float xMultiplier)
+        /// <param name="index">The index in the collection to update at.</param>
+        /// <param name="value">The new x value.</param>
+        public virtual void SetElementX(int index, float value)
         {
-            multiplier.x = xMultiplier;
+            index = WrapAroundAndClamp(index);
+            Vector3 currentValue = collection[index];
+            currentValue.x = value;
+            collection[index] = currentValue;
         }
 
         /// <summary>
-        /// Sets the y value to multiply the input y by.
+        /// Sets the y value of the <see cref="CurrentIndex"/> element.
         /// </summary>
-        /// <param name="yMultiplier">The new y multiplier value.</param>
-        public virtual void SetYMultiplier(float yMultiplier)
+        /// <param name="value">The new y value.</param>
+        public virtual void SetElementY(float value)
         {
-            multiplier.y = yMultiplier;
+            Vector3 currentValue = collection[CurrentIndex];
+            currentValue.y = value;
+            collection[CurrentIndex] = currentValue;
         }
 
         /// <summary>
-        /// Sets the z value to multiply the input z by.
+        /// Sets the y value of the given index element.
         /// </summary>
-        /// <param name="zMultiplier">The new z multiplier value.</param>
-        public virtual void SetZMultiplier(float zMultiplier)
+        /// <param name="index">The index in the collection to update at.</param>
+        /// <param name="value">The new y value.</param>
+        public virtual void SetElementY(int index, float value)
         {
-            multiplier.z = zMultiplier;
+            index = WrapAroundAndClamp(index);
+            Vector3 currentValue = collection[index];
+            currentValue.y = value;
+            collection[index] = currentValue;
         }
 
         /// <summary>
-        /// Multiplies the input by the multipliers.
+        /// Sets the z value of the <see cref="CurrentIndex"/> element.
         /// </summary>
-        /// <param name="input">The value to transform.</param>
-        /// <returns>The transformed value.</returns>
-        protected override Vector3 Process(Vector3 input)
+        /// <param name="value">The new z value.</param>
+        public virtual void SetElementZ(float value)
         {
-            return Vector3.Scale(input, multiplier);
+            Vector3 currentValue = collection[CurrentIndex];
+            currentValue.z = value;
+            collection[CurrentIndex] = currentValue;
+        }
+
+        /// <summary>
+        /// Sets the z value of the given index element.
+        /// </summary>
+        /// <param name="index">The index in the collection to update at.</param>
+        /// <param name="value">The new z value.</param>
+        public virtual void SetElementZ(int index, float value)
+        {
+            index = WrapAroundAndClamp(index);
+            Vector3 currentValue = collection[index];
+            currentValue.z = value;
+            collection[index] = currentValue;
+        }
+
+        /// <inheritdoc />
+        protected override Vector3 ProcessCollection()
+        {
+            return collection.Aggregate(Multiply);
+        }
+
+        /// <summary>
+        /// Multiplies two <see cref="Vector3"/> values.
+        /// </summary>
+        /// <param name="multiplicand">The value to be multiplied.</param>
+        /// <param name="multiplier">The value to multiply with.</param>
+        /// <returns>The calculated value.</returns>
+        protected virtual Vector3 Multiply(Vector3 multiplicand, Vector3 multiplier)
+        {
+            return Vector3.Scale(multiplicand, multiplier);
         }
     }
 }

--- a/Tests/Editor/Data/Type/Transformation/FloatAdderTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/FloatAdderTest.cs
@@ -37,7 +37,7 @@ namespace Test.VRTK.Core.Data.Type.Transformation
 
             subject.SetElement(0, 1f);
             subject.SetElement(1, 2f);
-            subject.SetIndex(2);
+            subject.CurrentIndex = 2;
             float result = subject.Transform(3f);
 
             Assert.AreEqual(6f, result);

--- a/Tests/Editor/Data/Type/Transformation/FloatMultiplierTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/FloatMultiplierTest.cs
@@ -5,6 +5,7 @@ namespace Test.VRTK.Core.Data.Type.Transformation
     using UnityEngine;
     using NUnit.Framework;
     using Test.VRTK.Core.Utility.Mock;
+    using System.Collections.Generic;
 
     public class FloatMultiplierTest
     {
@@ -30,11 +31,13 @@ namespace Test.VRTK.Core.Data.Type.Transformation
         {
             UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
             subject.Transformed.AddListener(transformedListenerMock.Listen);
-            subject.SetMultiplier(2f);
+            subject.collection = new List<float>(new float[2]);
+            subject.SetElement(0, 2f);
 
             Assert.AreEqual(0f, subject.Result);
             Assert.IsFalse(transformedListenerMock.Received);
 
+            subject.CurrentIndex = 1;
             float result = subject.Transform(2f);
 
             Assert.AreEqual(4f, result);
@@ -47,7 +50,8 @@ namespace Test.VRTK.Core.Data.Type.Transformation
         {
             UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
             subject.Transformed.AddListener(transformedListenerMock.Listen);
-            subject.SetMultiplier(2f);
+            subject.collection = new List<float>(new float[2]);
+            subject.SetElement(0, 2f);
             subject.gameObject.SetActive(false);
 
             Assert.AreEqual(0f, subject.Result);
@@ -65,7 +69,8 @@ namespace Test.VRTK.Core.Data.Type.Transformation
         {
             UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
             subject.Transformed.AddListener(transformedListenerMock.Listen);
-            subject.SetMultiplier(2f);
+            subject.collection = new List<float>(new float[2]);
+            subject.SetElement(0, 2f);
             subject.gameObject.SetActive(false);
 
             Assert.AreEqual(0f, subject.Result);

--- a/Tests/Editor/Data/Type/Transformation/Vector2MultiplierTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Vector2MultiplierTest.cs
@@ -5,6 +5,7 @@ namespace Test.VRTK.Core.Data.Type.Transformation
     using UnityEngine;
     using NUnit.Framework;
     using Test.VRTK.Core.Utility.Mock;
+    using System.Collections.Generic;
 
     public class Vector2MultiplierTest
     {
@@ -30,8 +31,10 @@ namespace Test.VRTK.Core.Data.Type.Transformation
         {
             UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
             subject.Transformed.AddListener(transformedListenerMock.Listen);
-            subject.SetXMultiplier(3f);
-            subject.SetYMultiplier(4f);
+            subject.collection = new List<Vector2>(new Vector2[2]);
+            subject.SetElementX(0, 3f);
+            subject.SetElementY(0, 4f);
+            subject.CurrentIndex = 1;
 
             Assert.AreEqual(Vector2.zero, subject.Result);
             Assert.IsFalse(transformedListenerMock.Received);
@@ -50,8 +53,10 @@ namespace Test.VRTK.Core.Data.Type.Transformation
         {
             UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
             subject.Transformed.AddListener(transformedListenerMock.Listen);
-            subject.SetXMultiplier(3f);
-            subject.SetYMultiplier(4f);
+            subject.collection = new List<Vector2>(new Vector2[2]);
+            subject.SetElementX(0, 3f);
+            subject.SetElementY(0, 4f);
+            subject.CurrentIndex = 1;
             subject.gameObject.SetActive(false);
 
             Assert.AreEqual(Vector2.zero, subject.Result);
@@ -70,8 +75,10 @@ namespace Test.VRTK.Core.Data.Type.Transformation
         {
             UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
             subject.Transformed.AddListener(transformedListenerMock.Listen);
-            subject.SetXMultiplier(3f);
-            subject.SetYMultiplier(4f);
+            subject.collection = new List<Vector2>(new Vector2[2]);
+            subject.SetElementX(0, 3f);
+            subject.SetElementY(0, 4f);
+            subject.CurrentIndex = 1;
             subject.enabled = false;
 
             Assert.AreEqual(Vector2.zero, subject.Result);

--- a/Tests/Editor/Data/Type/Transformation/Vector3MultiplierTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Vector3MultiplierTest.cs
@@ -5,6 +5,7 @@ namespace Test.VRTK.Core.Data.Type.Transformation
     using UnityEngine;
     using NUnit.Framework;
     using Test.VRTK.Core.Utility.Mock;
+    using System.Collections.Generic;
 
     public class Vector3MultiplierTest
     {
@@ -30,10 +31,9 @@ namespace Test.VRTK.Core.Data.Type.Transformation
         {
             UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
             subject.Transformed.AddListener(transformedListenerMock.Listen);
-            subject.SetXMultiplier(3f);
-            subject.SetYMultiplier(4f);
-            subject.SetZMultiplier(5f);
-
+            subject.collection = new List<Vector3>(new Vector3[2]);
+            subject.SetElement(0, new Vector3(3f, 4f, 5f));
+            subject.CurrentIndex = 1;
             Assert.AreEqual(Vector3.zero, subject.Result);
             Assert.IsFalse(transformedListenerMock.Received);
 
@@ -51,9 +51,10 @@ namespace Test.VRTK.Core.Data.Type.Transformation
         {
             UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
             subject.Transformed.AddListener(transformedListenerMock.Listen);
-            subject.SetXMultiplier(3f);
-            subject.SetYMultiplier(4f);
-            subject.SetZMultiplier(5f);
+            subject.collection = new List<Vector3>(new Vector3[2]);
+            subject.SetElement(0, new Vector3(3f, 4f, 5f));
+            subject.CurrentIndex = 1;
+
             subject.gameObject.SetActive(false);
 
             Assert.AreEqual(Vector3.zero, subject.Result);
@@ -72,9 +73,9 @@ namespace Test.VRTK.Core.Data.Type.Transformation
         {
             UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
             subject.Transformed.AddListener(transformedListenerMock.Listen);
-            subject.SetXMultiplier(3f);
-            subject.SetYMultiplier(4f);
-            subject.SetZMultiplier(5f);
+            subject.collection = new List<Vector3>(new Vector3[2]);
+            subject.SetElement(0, new Vector3(3f, 4f, 5f));
+            subject.CurrentIndex = 1;
             subject.enabled = false;
 
             Assert.AreEqual(Vector3.zero, subject.Result);

--- a/Tests/Editor/Data/Type/Transformation/Vector3SubtractorTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Vector3SubtractorTest.cs
@@ -38,7 +38,7 @@ namespace Test.VRTK.Core.Data.Type.Transformation
 
             subject.SetElement(0, Vector3.one * 3f);
             subject.SetElement(1, Vector3.one);
-            subject.SetIndex(2);
+            subject.CurrentIndex = 2;
             Vector3 result = subject.Transform(Vector3.one);
 
             Assert.AreEqual(Vector3.one, result);


### PR DESCRIPTION
The various Multipler transformations now extend CollectionAggregator
as multiplication is an aggregate function across a collection of
values.

Now it's possible to multiple a range of float/vector2/vector3 values
as they extend the base aggregator.

The prefabs have been updated and the general rule is the dynamic
multiplication value is always index 0 and the multipler is always
set to index 1. This way the event updating the dynamic value never
has to bother setting the current index in the collection.