### PR TITLE
fix(Extension): remove unused variable from ColliderExtension test

### DIFF
--- a/Tests/Editor/Extension/ColliderExtensionsTest.cs
+++ b/Tests/Editor/Extension/ColliderExtensionsTest.cs
@@ -14,7 +14,7 @@ namespace Test.VRTK.Core.Extension
             GameObject child = new GameObject();
             child.transform.SetParent(parent.transform);
 
-            Rigidbody rigidbody = parent.AddComponent<Rigidbody>();
+            parent.AddComponent<Rigidbody>();
             BoxCollider collider = child.AddComponent<BoxCollider>();
 
             Assert.AreEqual(parent.transform, collider.GetContainingTransform());


### PR DESCRIPTION
The ColliderExtension test required a rigidbody to be added to the
parent component, but it never actually used the rigidbody variable
within the test as the presence of the rigidbody is just there to
get the underlying code to correctly find the appropriate GameObject
for testing.