### PR TITLE
feat(MovementAmplifier): amplify movement of a game object - resolves #49

### DIFF
--- a/Prefabs/Locomotion/Movement/MovementAmplifier.meta
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2396a6e31f2d498f9e829b2cc897424c
+timeCreated: 1545573618

--- a/Prefabs/Locomotion/Movement/MovementAmplifier/MovementAmplifier.prefab
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier/MovementAmplifier.prefab
@@ -1,0 +1,921 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1296302406590266}
+  m_IsPrefabParent: 1
+--- !u!1 &1031275965452658
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4320635376411300}
+  - component: {fileID: 114683042693701376}
+  m_Layer: 0
+  m_Name: Multiply
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1086647023152054
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4109977519210390}
+  - component: {fileID: 114338818901367866}
+  m_Layer: 0
+  m_Name: MoveTarget
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1173348994459298
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4891192692534390}
+  - component: {fileID: 114377692372797170}
+  - component: {fileID: 114250938589785244}
+  - component: {fileID: 114105985074516834}
+  - component: {fileID: 114875471641467916}
+  m_Layer: 0
+  m_Name: MoveToSourceY
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1229218066911268
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4428046216080474}
+  - component: {fileID: 114849671001180176}
+  m_Layer: 0
+  m_Name: MomentProcessor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1296302406590266
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4051312477943264}
+  - component: {fileID: 114278046284068392}
+  m_Layer: 0
+  m_Name: MovementAmplifier
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1312340796486872
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4219302612427050}
+  - component: {fileID: 114782358205031066}
+  m_Layer: 0
+  m_Name: Internal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1370478312926814
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4693491223827264}
+  m_Layer: 0
+  m_Name: Movement
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1381729630411102
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4871812051726806}
+  - component: {fileID: 114936454740504034}
+  - component: {fileID: 114856444510103800}
+  - component: {fileID: 114297957598228628}
+  m_Layer: 0
+  m_Name: GetSourceMovement
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1485024953633994
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4510033939423762}
+  - component: {fileID: 114273815781327958}
+  - component: {fileID: 114379391593044462}
+  m_Layer: 0
+  m_Name: CheckDistance
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1544671449446328
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4153789395572902}
+  - component: {fileID: 114240824479785088}
+  - component: {fileID: 114745694446295306}
+  - component: {fileID: 114559784510935700}
+  m_Layer: 0
+  m_Name: MoveInSourceDirection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1560522712979762
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4096394858003668}
+  m_Layer: 0
+  m_Name: RadiusOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1809199976699076
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4745700717331646}
+  - component: {fileID: 114334631856636516}
+  m_Layer: 0
+  m_Name: MoveRadiusOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1833241684301458
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4911137219287474}
+  - component: {fileID: 114516617384978064}
+  m_Layer: 0
+  m_Name: SubtractRadius
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4051312477943264
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1296302406590266}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4219302612427050}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4096394858003668
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1560522712979762}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4891192692534390}
+  - {fileID: 4510033939423762}
+  m_Father: {fileID: 4219302612427050}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4109977519210390
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1086647023152054}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4153789395572902}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4153789395572902
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1544671449446328}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4320635376411300}
+  - {fileID: 4745700717331646}
+  - {fileID: 4109977519210390}
+  m_Father: {fileID: 4693491223827264}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4219302612427050
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1312340796486872}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4428046216080474}
+  - {fileID: 4096394858003668}
+  - {fileID: 4693491223827264}
+  m_Father: {fileID: 4051312477943264}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4320635376411300
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1031275965452658}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4153789395572902}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4428046216080474
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1229218066911268}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4219302612427050}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4510033939423762
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1485024953633994}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4096394858003668}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4693491223827264
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1370478312926814}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4871812051726806}
+  - {fileID: 4911137219287474}
+  - {fileID: 4153789395572902}
+  m_Father: {fileID: 4219302612427050}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4745700717331646
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1809199976699076}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4153789395572902}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4871812051726806
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1381729630411102}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4693491223827264}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4891192692534390
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1173348994459298}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4096394858003668}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4911137219287474
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1833241684301458}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4693491223827264}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114105985074516834
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1173348994459298}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b04ace9c0d404b309ad4fefb13690d36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DifferenceExtracted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114875471641467916}
+        m_MethodName: DoIncrementProperty
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparatorEventDataExtractor+Vector3UnityEvent,
+      Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  DistanceExtracted:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparatorEventDataExtractor+FloatUnityEvent,
+      Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!114 &114240824479785088
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1544671449446328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b04ace9c0d404b309ad4fefb13690d36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DifferenceExtracted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114745694446295306}
+        m_MethodName: DoTransform
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparatorEventDataExtractor+Vector3UnityEvent,
+      Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  DistanceExtracted:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparatorEventDataExtractor+FloatUnityEvent,
+      Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!114 &114250938589785244
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1173348994459298}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6e5bdd7c9c796d45b83b486c20fdec4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 1560522712979762}
+  target: {fileID: 0}
+  distanceThreshold: 0
+  ThresholdExceeded:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114105985074516834}
+        m_MethodName: Extract
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  ThresholdResumed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!114 &114273815781327958
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1485024953633994}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  process:
+    field: {fileID: 114379391593044462}
+  onlyProcessOnActiveAndEnabled: 1
+  utilization: 1
+--- !u!114 &114278046284068392
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1296302406590266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aeb966491f2d49dcace7c9cc321e53d6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 0}
+  target: {fileID: 0}
+  ignoredRadius: 0.25
+  multiplier: 2
+  internalSetup: {fileID: 114782358205031066}
+--- !u!114 &114297957598228628
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1381729630411102}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b04ace9c0d404b309ad4fefb13690d36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DifferenceExtracted:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparatorEventDataExtractor+Vector3UnityEvent,
+      Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  DistanceExtracted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114516617384978064}
+        m_MethodName: DoTransform
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparatorEventDataExtractor+FloatUnityEvent,
+      Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!114 &114334631856636516
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1809199976699076}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 885d222bc36da3d489909c0ad5a6ae1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 1560522712979762}
+  useLocalValues: 0
+  lockAxis:
+    xState: 0
+    yState: 1
+    zState: 0
+  rotationOffset: {fileID: 0}
+--- !u!114 &114338818901367866
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1086647023152054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 885d222bc36da3d489909c0ad5a6ae1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 0}
+  useLocalValues: 0
+  lockAxis:
+    xState: 0
+    yState: 1
+    zState: 0
+  rotationOffset: {fileID: 0}
+--- !u!114 &114377692372797170
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1173348994459298}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  process:
+    field: {fileID: 114250938589785244}
+  onlyProcessOnActiveAndEnabled: 1
+  utilization: 1
+--- !u!114 &114379391593044462
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1485024953633994}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6e5bdd7c9c796d45b83b486c20fdec4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 0}
+  target: {fileID: 1560522712979762}
+  distanceThreshold: 0.25
+  ThresholdExceeded:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114856444510103800}
+        m_MethodName: set_enabled
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  ThresholdResumed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114856444510103800}
+        m_MethodName: set_enabled
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!114 &114516617384978064
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1833241684301458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1a514ee12ca3644b98dbebcf65f8705, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Transformed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114559784510935700}
+        m_MethodName: SetMagnitude
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Data.Type.Transformation.FloatAdder+UnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  collection:
+  - 0
+  - -0.249
+--- !u!114 &114559784510935700
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1544671449446328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0242f830f14348cb9d4d0edb83babb31, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Transformed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114334631856636516}
+        m_MethodName: DoIncrementProperty
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 114683042693701376}
+        m_MethodName: DoTransform
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Data.Type.Transformation.Vector3MagnitudeSetter+UnityEvent,
+      Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  magnitude: 0
+--- !u!114 &114683042693701376
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1031275965452658}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a636708cc9984ae49bda056f99f79b20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Transformed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114334631856636516}
+        m_MethodName: DoIncrementProperty
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 114338818901367866}
+        m_MethodName: DoIncrementProperty
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Data.Type.Transformation.Vector3Multiplier+UnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  collection:
+  - {x: 0, y: 0, z: 0}
+  - {x: 1, y: 1, z: 1}
+--- !u!114 &114745694446295306
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1544671449446328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a636708cc9984ae49bda056f99f79b20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Transformed:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114559784510935700}
+        m_MethodName: DoTransform
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Data.Type.Transformation.Vector3Multiplier+UnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  collection:
+  - {x: 0, y: 0, z: 0}
+  - {x: -1, y: -1, z: -1}
+--- !u!114 &114782358205031066
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1312340796486872}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bb869d9b7a34053a63fd43b61fd0b62, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  facade: {fileID: 114278046284068392}
+  radiusOriginMover: {fileID: 114250938589785244}
+  distanceChecker: {fileID: 114379391593044462}
+  objectMover: {fileID: 114856444510103800}
+  radiusSubtractor: {fileID: 114516617384978064}
+  radiusStabilizer: 0.001
+  movementMultiplier: {fileID: 114683042693701376}
+  targetPositionMutator: {fileID: 114338818901367866}
+--- !u!114 &114849671001180176
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1229218066911268}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c0eab237e25807459af1c5caf4d3d33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  momentToProcess: 2
+  processes:
+  - {fileID: 114377692372797170}
+  - {fileID: 114273815781327958}
+  - {fileID: 114936454740504034}
+--- !u!114 &114856444510103800
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1381729630411102}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6e5bdd7c9c796d45b83b486c20fdec4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 0}
+  target: {fileID: 1560522712979762}
+  distanceThreshold: 0
+  ThresholdExceeded:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114297957598228628}
+        m_MethodName: Extract
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 114240824479785088}
+        m_MethodName: Extract
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  ThresholdResumed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: VRTK.Core.Tracking.Follow.ObjectDistanceComparator+UnityEvent, Assembly-CSharp,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!114 &114875471641467916
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1173348994459298}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 885d222bc36da3d489909c0ad5a6ae1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 1560522712979762}
+  useLocalValues: 0
+  lockAxis:
+    xState: 1
+    yState: 0
+    zState: 1
+  rotationOffset: {fileID: 0}
+--- !u!114 &114936454740504034
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1381729630411102}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  process:
+    field: {fileID: 114856444510103800}
+  onlyProcessOnActiveAndEnabled: 1
+  utilization: 1

--- a/Prefabs/Locomotion/Movement/MovementAmplifier/MovementAmplifier.prefab.meta
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier/MovementAmplifier.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1463c65f289de2940abcf05dbb937a8a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources.meta
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f5328903da164b31861d996b364faac2
+timeCreated: 1545573669

--- a/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts.meta
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fd2210248d5f44f48f5bd01110dddbb2
+timeCreated: 1545573672

--- a/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts/MovementAmplifierFacade.cs
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts/MovementAmplifierFacade.cs
@@ -1,0 +1,45 @@
+﻿namespace VRTK.Core.Prefabs.Locomotion.Movement.MovementAmplifier
+{
+    using UnityEngine;
+    using VRTK.Core.Data.Attribute;
+
+    /// <summary>
+    /// The public interface for the MovementAmplifier prefab.
+    /// </summary>
+    public class MovementAmplifierFacade : MonoBehaviour
+    {
+        #region Tracking Settings
+        /// <summary>
+        /// The source to observe movement of.
+        /// </summary>
+        [Header("Tracking Settings"), Tooltip("The source to observe movement of.")]
+        public GameObject source;
+        /// <summary>
+        /// The target to apply amplified movement to.
+        /// </summary>
+        [Tooltip("The target to apply amplified movement to.")]
+        public GameObject target;
+        #endregion
+
+        #region Movement Settings
+        /// <summary>
+        /// The radius in which <see cref="source"/> movement is ignored. Too small values can result in movement amplification happening during crouching which is often unexpected.
+        /// </summary>
+        [Header("Movement Settings"), Tooltip("The radius in which source movement is ignored. Too small values can result in movement amplification happening during crouching which is often unexpected.")]
+        public float ignoredRadius = 0.25f;
+        /// <summary>
+        /// How much to amplify movement of <see cref="source"/> to apply to <see cref="target"/>.
+        /// </summary>
+        [Tooltip("How much to amplify movement of source to apply to target.")]
+        public float multiplier = 2f;
+        #endregion
+
+        #region Internal Settings
+        /// <summary>
+        /// The linked Internal Setup.
+        /// </summary>
+        [Header("Internal Settings"), Tooltip("The linked Internal Setup."), InternalSetting]
+        public MovementAmplifierInternalSetup internalSetup;
+        #endregion
+    }
+}

--- a/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts/MovementAmplifierFacade.cs.meta
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts/MovementAmplifierFacade.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: aeb966491f2d49dcace7c9cc321e53d6
+timeCreated: 1545573637

--- a/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts/MovementAmplifierInternalSetup.cs
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts/MovementAmplifierInternalSetup.cs
@@ -1,0 +1,81 @@
+﻿namespace VRTK.Core.Prefabs.Locomotion.Movement.MovementAmplifier
+{
+    using UnityEngine;
+    using VRTK.Core.Data.Operation;
+    using VRTK.Core.Data.Type.Transformation;
+    using VRTK.Core.Tracking.Follow;
+
+    /// <summary>
+    /// Sets up the MovementAmplifier prefab based on the provided user settings.
+    /// </summary>
+    public class MovementAmplifierInternalSetup : MonoBehaviour
+    {
+        #region Facade Settings
+        /// <summary>
+        /// The public interface facade.
+        /// </summary>
+        [Header("Facade Settings"), Tooltip("The public interface facade.")]
+        public MovementAmplifierFacade facade;
+        #endregion
+
+        #region Reference Settings
+        /// <summary>
+        /// Moves the radius origin.
+        /// </summary>
+        [Header("Reference Settings"), Tooltip("Moves the radius origin.")]
+        public ObjectDistanceComparator radiusOriginMover;
+        /// <summary>
+        /// Determines whether <see cref="MovementAmplifierFacade.source"/> is inside the radius.
+        /// </summary>
+        [Tooltip("Determines whether MovementAmplifierFacade.source is inside the radius.")]
+        public ObjectDistanceComparator distanceChecker;
+        /// <summary>
+        /// Moves the objects.
+        /// </summary>
+        [Tooltip("Moves the objects.")]
+        public ObjectDistanceComparator objectMover;
+        /// <summary>
+        /// Subtracts the radius.
+        /// </summary>
+        [Tooltip("Subtracts the radius.")]
+        public FloatAdder radiusSubtractor;
+        /// <summary>
+        /// Stabilizes the radius by ensuring <see cref="MovementAmplifierFacade.target"/> moves back into the radius.
+        /// </summary>
+        [Tooltip("Stabilizes the radius by ensuring MovementAmplifierFacade.target moves back into the radius.")]
+        public float radiusStabilizer = 0.001f;
+        /// <summary>
+        /// Amplifies the movement.
+        /// </summary>
+        [Tooltip("Amplifies the movement.")]
+        public Vector3Multiplier movementMultiplier;
+        /// <summary>
+        /// Moves the target.
+        /// </summary>
+        [Tooltip("Moves the target.")]
+        public TransformPositionMutator targetPositionMutator;
+        #endregion
+
+        public virtual void OnEnable()
+        {
+            radiusOriginMover.transform.parent.position = facade.source.transform.position;
+            radiusOriginMover.SetTarget(facade.source);
+
+            distanceChecker.SetSource(facade.source);
+            distanceChecker.distanceThreshold = facade.ignoredRadius;
+
+            objectMover.SetSource(facade.source);
+
+            radiusSubtractor.SetElement(1, -facade.ignoredRadius + radiusStabilizer);
+
+            movementMultiplier.SetElement(1, Vector3.one * (facade.multiplier - 1f));
+
+            targetPositionMutator.SetTarget(facade.target);
+        }
+
+        public virtual void OnDisable()
+        {
+            objectMover.enabled = false;
+        }
+    }
+}

--- a/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts/MovementAmplifierInternalSetup.cs.meta
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier/SharedResources/Scripts/MovementAmplifierInternalSetup.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6bb869d9b7a34053a63fd43b61fd0b62
+timeCreated: 1545905750

--- a/Scripts/Data/Type/Transformation/Vector3MagnitudeSetter.cs
+++ b/Scripts/Data/Type/Transformation/Vector3MagnitudeSetter.cs
@@ -1,0 +1,54 @@
+﻿namespace VRTK.Core.Data.Type.Transformation
+{
+    using System;
+    using UnityEngine;
+    using UnityEngine.Events;
+
+    /// <summary>
+    /// Transforms a <see cref="Vector3"/> by changing its magnitude.
+    /// </summary>
+    public class Vector3MagnitudeSetter : Transformer<Vector3, Vector3, Vector3MagnitudeSetter.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="Vector3"/> with the changed magnitude.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<Vector3>
+        {
+        }
+
+        /// <summary>
+        /// The magnitude to use when transforming values.
+        /// </summary>
+        [Tooltip("The magnitude to use when transforming values.")]
+        public float magnitude = 1f;
+
+        /// <summary>
+        /// Sets the magnitude to use.
+        /// </summary>
+        /// <param name="magnitude">The magnitude to use when transforming values.</param>
+        public void SetMagnitude(float magnitude)
+        {
+            this.magnitude = magnitude;
+        }
+
+        /// <summary>
+        /// Sets the magnitude to use.
+        /// </summary>
+        /// <param name="magnitudeSource">The source of the magnitude to use when transforming values.</param>
+        public void SetMagnitude(Vector3 magnitudeSource)
+        {
+            magnitude = magnitudeSource.magnitude;
+        }
+
+        /// <summary>
+        /// Transforms the given <see cref="Vector3"/> by changing its magnitude to <see cref="magnitude"/>.
+        /// </summary>
+        /// <param name="input">The value to change the magnitude of.</param>
+        /// <returns>A new <see cref="Vector3"/> with the same direction as <paramref name="input"/> and a magnitude of <see cref="magnitude"/>.</returns>
+        protected override Vector3 Process(Vector3 input)
+        {
+            return input.normalized * magnitude;
+        }
+    }
+}

--- a/Scripts/Data/Type/Transformation/Vector3MagnitudeSetter.cs.meta
+++ b/Scripts/Data/Type/Transformation/Vector3MagnitudeSetter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0242f830f14348cb9d4d0edb83babb31
+timeCreated: 1545901103

--- a/Tests/Editor/Data/Type/Transformation/Vector3MagnitudeSetterTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Vector3MagnitudeSetterTest.cs
@@ -1,0 +1,69 @@
+﻿using VRTK.Core.Data.Type.Transformation;
+
+namespace Test.VRTK.Core.Data.Type.Transformation
+{
+    using NUnit.Framework;
+    using Test.VRTK.Core.Utility.Mock;
+    using UnityEngine;
+
+    public class Vector3MagnitudeSetterTest
+    {
+        private Vector3MagnitudeSetter subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            subject = new GameObject().AddComponent<Vector3MagnitudeSetter>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject.gameObject);
+        }
+
+        [TestCase(0f), TestCase(1f), TestCase(-2f), TestCase(123f), TestCase(float.MaxValue)]
+        public void SetFloatMagnitude(float expected)
+        {
+            subject.magnitude = 2f;
+
+            Assert.AreEqual(2f, subject.magnitude);
+
+            subject.SetMagnitude(expected);
+
+            Assert.AreEqual(expected, subject.magnitude);
+        }
+
+        [Test]
+        public void SetVectorMagnitude()
+        {
+            subject.magnitude = 2f;
+
+            Assert.AreEqual(2f, subject.magnitude);
+
+            Vector3 expected = new Vector3(1f, 2f, 3f);
+            subject.SetMagnitude(expected);
+
+            Assert.AreEqual(expected.magnitude, subject.magnitude);
+        }
+
+        [Test]
+        public void Process()
+        {
+            UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
+            subject.Transformed.AddListener(transformedListenerMock.Listen);
+
+            Assert.AreEqual(Vector3.zero, subject.Result);
+            Assert.IsFalse(transformedListenerMock.Received);
+
+            subject.magnitude = 2f;
+            Vector3 input = new Vector3(1f, -2f, 5f);
+            Vector3 result = subject.Transform(input);
+            Vector3 expectedResult = new Vector3(0.3651484f, -0.7302967f, 1.825742f);
+
+            Assert.IsTrue(expectedResult == result);
+            Assert.IsTrue(expectedResult == subject.Result);
+            Assert.IsTrue(transformedListenerMock.Received);
+        }
+    }
+}

--- a/Tests/Editor/Data/Type/Transformation/Vector3MagnitudeSetterTest.cs.meta
+++ b/Tests/Editor/Data/Type/Transformation/Vector3MagnitudeSetterTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 78bcc0e2082c444f9b7bb8badfc80465
+timeCreated: 1546141457


### PR DESCRIPTION
The movement of a game object can be amplified by applying the same
movement to another object. The feature comes with a multiplier
allows setting the amplification amount as well as a threshold that
allows ignoring movement in a radius. In VR experiences this feature
can be used to amplify movement of the headset to allow traveling
larger distances than the physical play area allows. The threshold
radius prevents amplifying movement while the user is not moving and
instead just crouches.