### PR TITLE
fix(Haptics): ensure ActiveProcess is set when processor enabled

### DIFF
--- a/Scripts/Haptics/HapticProcessor.cs
+++ b/Scripts/Haptics/HapticProcessor.cs
@@ -53,5 +53,10 @@
                 ActiveProcess.Cancel();
             }
         }
+
+        protected virtual void OnEnable()
+        {
+            ActiveProcess = hapticProcesses.EmptyIfNull().FirstOrDefault(process => process.IsActive());
+        }
     }
 }


### PR DESCRIPTION
There was an issue where the `IsActive()` check on the HapticProcessor
would always report false because the ActiveProcess was never set until
the `Begin()` method was called, but the `IsActive()` check was being
done before the `Begin()` method was executed.

This resulted in the HapticProcessor never being able to actually
process any valid HapticProcesses.

The fix is to just set the ActiveProcess in `OnEnable` so at least one
is set when it is enabled.