### PR TITLE
refactor(Prefabs): apply consistent inspector headers

### DIFF
--- a/Prefabs/Interactions/Interactables/SharedResources/Scripts/ClimbInteractableFacade.cs
+++ b/Prefabs/Interactions/Interactables/SharedResources/Scripts/ClimbInteractableFacade.cs
@@ -9,11 +9,11 @@
     /// </summary>
     public class ClimbInteractableFacade : MonoBehaviour
     {
-        #region Facade Settings
+        #region Climb Settings
         /// <summary>
         /// The <see cref="ClimbFacade"/> to use.
         /// </summary>
-        [Header("Facade Settings"), Tooltip("The Climb Facade to use.")]
+        [Header("Climb Settings"), Tooltip("The Climb Facade to use.")]
         public ClimbFacade climbFacade;
         /// <summary>
         /// The multiplier to apply to the velocity of the interactor when the interactable is released and climbing stops.

--- a/Prefabs/Locomotion/BodyRepresentation/SharedResources/Scripts/BodyRepresentationFacade.cs
+++ b/Prefabs/Locomotion/BodyRepresentation/SharedResources/Scripts/BodyRepresentationFacade.cs
@@ -12,11 +12,11 @@
     /// </summary>
     public class BodyRepresentationFacade : MonoBehaviour
     {
-        #region Facade Settings
+        #region Source Settings
         /// <summary>
         /// The object to follow.
         /// </summary>
-        [Header("Facade Settings"), Tooltip("The object to follow.")]
+        [Header("Source Settings"), Tooltip("The object to follow.")]
         public GameObject source;
         /// <summary>
         /// The thickness of <see cref="source"/> to be used when resolving body collisions.
@@ -28,10 +28,13 @@
         /// </summary>
         [Tooltip("An optional offset for the source to use.")]
         public GameObject offset;
+        #endregion
+
+        #region Interaction Settings
         /// <summary>
         /// A collection of interactors to exclude from physics collision checks.
         /// </summary>
-        [Tooltip("A collection of interactors to exclude from physics collision checks."), SerializeField]
+        [Header("Interaction Settings"), Tooltip("A collection of interactors to exclude from physics collision checks."), SerializeField]
         protected List<InteractorFacade> ignoredInteractors = new List<InteractorFacade>();
         #endregion
 

--- a/Prefabs/Locomotion/Movement/AxesToVector3/SharedResources/Scripts/AxesToVector3InternalSetup.cs
+++ b/Prefabs/Locomotion/Movement/AxesToVector3/SharedResources/Scripts/AxesToVector3InternalSetup.cs
@@ -19,11 +19,11 @@
         public AxesToVector3Facade facade;
         #endregion
 
-        #region Linked Settings
+        #region Reference Settings
         /// <summary>
         /// The lateral <see cref="FloatAction"/> to map to.
         /// </summary>
-        [Header("Linked Settings"), Tooltip("The lateral FloatAction to map to.")]
+        [Header("Reference Settings"), Tooltip("The lateral FloatAction to map to.")]
         public FloatAction lateralAxis;
         /// <summary>
         /// The longitudinal <see cref="FloatAction"/> to map to.

--- a/Prefabs/Locomotion/Movement/Climb/SharedResources/Scripts/ClimbFacade.cs
+++ b/Prefabs/Locomotion/Movement/Climb/SharedResources/Scripts/ClimbFacade.cs
@@ -12,11 +12,11 @@
     /// </summary>
     public class ClimbFacade : MonoBehaviour
     {
-        #region Facade Settings
+        #region Control Settings
         /// <summary>
         /// The body representation to control.
         /// </summary>
-        [Header("Facade Settings"), Tooltip("The body representation to control.")]
+        [Header("Control Settings"), Tooltip("The body representation to control.")]
         public BodyRepresentationFacade bodyRepresentationFacade;
         #endregion
 


### PR DESCRIPTION
The prefabs now have consistent inspector headers on the facades
and the internal scripts.