### PR TITLE
feat(Query): add obscurance query - resolves #51

### DIFF
--- a/Scripts/Tracking/Query.meta
+++ b/Scripts/Tracking/Query.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: acc35e3754bf497a9be93539c702e458
+timeCreated: 1546252909

--- a/Scripts/Tracking/Query/ObscuranceQuery.cs
+++ b/Scripts/Tracking/Query/ObscuranceQuery.cs
@@ -1,0 +1,91 @@
+﻿namespace VRTK.Core.Tracking.Query
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using System.Linq;
+    using VRTK.Core.Cast;
+    using VRTK.Core.Process;
+
+    /// <summary>
+    /// Determines whether any <see cref="Collider"/> obscures a line between two <see cref="GameObject"/>s.
+    /// </summary>
+    /// <remarks>
+    /// The check is done by utilizing physics and as such a <see cref="Collider"/> is needed on <see cref="target"/>.
+    /// </remarks>
+    public class ObscuranceQuery : MonoBehaviour, IProcessable
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="T:RaycastHit[]"/>.
+        /// </summary>
+        [Serializable]
+        public class HitEvent : UnityEvent<RaycastHit[]>
+        {
+        }
+
+        /// <summary>
+        /// Defines the source location that the raycast will originate from towards the <see cref="target"/> location.
+        /// </summary>
+        [Tooltip("Defines the source location that the raycast will originate from towards the target location.")]
+        public GameObject source;
+        /// <summary>
+        /// Defines the target location that the raycast will attain to reach from the originating <see cref="source"/> location.
+        /// </summary>
+        [Tooltip("Defines the target location that the raycast will attain to reach from the originating source location.")]
+        public Collider target;
+        /// <summary>
+        /// Optional settings to use when doing the raycast.
+        /// </summary>
+        [Tooltip("Optional settings to use when doing the raycast.")]
+        public PhysicsCast physicsCast;
+
+        /// <summary>
+        /// Emitted when the raycast from <see cref="source"/> to <see cref="target"/> is obscured by another <see cref="Collider"/>.
+        /// </summary>
+        public HitEvent TargetObscured = new HitEvent();
+        /// <summary>
+        /// Emitted when the raycast from <see cref="source"/> is reaching <see cref="target"/> and is not obscured by another <see cref="Collider"/>.
+        /// </summary>
+        public UnityEvent TargetUnobscured = new UnityEvent();
+
+        /// <summary>
+        /// Whether the raycast from <see cref="source"/> to <see cref="target"/> was previously obscured by another <see cref="Collider"/>.
+        /// </summary>
+        protected bool? wasPreviouslyObscured;
+
+        /// <summary>
+        /// Casts a ray from the <see cref="source"/> origin location towards the <see cref="target"/> destination location and determines whether the raycast is blocked by another <see cref="Collider"/>.
+        /// </summary>
+        public virtual void Process()
+        {
+            Vector3 difference = target.transform.position - source.transform.position;
+            Ray ray = new Ray(source.transform.position, difference);
+            RaycastHit[] raycastHits = PhysicsCast.RaycastAll(
+                physicsCast,
+                ray,
+                difference.magnitude,
+                Physics.IgnoreRaycastLayer);
+            bool isObscured = raycastHits.Any(hit => hit.transform.gameObject != source && hit.collider != target);
+            if (isObscured == wasPreviouslyObscured)
+            {
+                return;
+            }
+
+            wasPreviouslyObscured = isObscured;
+
+            if (isObscured)
+            {
+                TargetObscured?.Invoke(raycastHits);
+            }
+            else
+            {
+                TargetUnobscured?.Invoke();
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            wasPreviouslyObscured = null;
+        }
+    }
+}

--- a/Scripts/Tracking/Query/ObscuranceQuery.cs.meta
+++ b/Scripts/Tracking/Query/ObscuranceQuery.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e9449de62d4f4d71adc6c8db47b76e7e
+timeCreated: 1546252941


### PR DESCRIPTION
A new component has been added that allows querying whether any
collider obscures a line between two GameObjects. An example use
case is disabling the teleportation functionality on a VR controller
while it's obscured from the headset to prevent users from moving
the controller through virtual walls and ultimately teleport through
it.