### PR TITLE
fix(Operation): replace negative with positive connotation of axis lock - fixes #238

### DIFF
--- a/Prefabs/CameraRig/PlayAreaRepresentation/PlayAreaRepresentation.prefab
+++ b/Prefabs/CameraRig/PlayAreaRepresentation/PlayAreaRepresentation.prefab
@@ -45,10 +45,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 0}
   useLocalValues: 1
-  lockAxis:
-    xState: 0
-    yState: 1
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 0
+    zState: 1
 --- !u!1 &1279233042894318
 GameObject:
   m_ObjectHideFlags: 0
@@ -561,10 +561,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 0}
   useLocalValues: 1
-  lockAxis:
-    xState: 0
-    yState: 1
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 0
+    zState: 1
   rotationOffset: {fileID: 0}
 --- !u!1 &1781126682336808
 GameObject:

--- a/Prefabs/CameraRig/SimulatedCameraRig/SimulatedCameraRig.prefab
+++ b/Prefabs/CameraRig/SimulatedCameraRig/SimulatedCameraRig.prefab
@@ -206,10 +206,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 1643489474284420}
   useLocalValues: 1
-  lockAxis:
-    xState: 0
-    yState: 0
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
 --- !u!114 &114208761435017372
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -224,10 +224,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 1643489474284420}
   useLocalValues: 1
-  lockAxis:
-    xState: 0
-    yState: 0
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
   rotationOffset: {fileID: 1643489474284420}
 --- !u!114 &114150379920675320
 MonoBehaviour:
@@ -1655,10 +1655,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 1581495199198194}
   useLocalValues: 1
-  lockAxis:
-    xState: 0
-    yState: 0
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
 --- !u!114 &114391431457905644
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1673,10 +1673,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 1581495199198194}
   useLocalValues: 1
-  lockAxis:
-    xState: 0
-    yState: 0
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
   rotationOffset: {fileID: 1581495199198194}
 --- !u!114 &114218838133236254
 MonoBehaviour:
@@ -2755,10 +2755,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 1143215074586592}
   useLocalValues: 1
-  lockAxis:
-    xState: 0
-    yState: 0
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
 --- !u!114 &114447943956170304
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2773,10 +2773,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 1121419207030402}
   useLocalValues: 1
-  lockAxis:
-    xState: 0
-    yState: 1
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 0
+    zState: 1
   rotationOffset: {fileID: 1143215074586592}
 --- !u!114 &114187299305708370
 MonoBehaviour:

--- a/Prefabs/Locomotion/Movement/Climb/Climb.prefab
+++ b/Prefabs/Locomotion/Movement/Climb/Climb.prefab
@@ -282,10 +282,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 0}
   useLocalValues: 1
-  lockAxis:
-    xState: 0
-    yState: 0
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
   rotationOffset: {fileID: 0}
 --- !u!1 &1461537113541358
 GameObject:

--- a/Prefabs/Locomotion/Movement/MovementAmplifier/MovementAmplifier.prefab
+++ b/Prefabs/Locomotion/Movement/MovementAmplifier/MovementAmplifier.prefab
@@ -118,10 +118,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 0}
   useLocalValues: 0
-  lockAxis:
-    xState: 0
-    yState: 1
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 0
+    zState: 1
   rotationOffset: {fileID: 0}
 --- !u!1 &1173348994459298
 GameObject:
@@ -256,10 +256,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 1560522712979762}
   useLocalValues: 0
-  lockAxis:
-    xState: 1
-    yState: 0
-    zState: 1
+  mutateOnAxis:
+    xState: 0
+    yState: 1
+    zState: 0
   rotationOffset: {fileID: 0}
 --- !u!1 &1229218066911268
 GameObject:
@@ -886,10 +886,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 1560522712979762}
   useLocalValues: 0
-  lockAxis:
-    xState: 0
-    yState: 1
-    zState: 0
+  mutateOnAxis:
+    xState: 1
+    yState: 0
+    zState: 1
   rotationOffset: {fileID: 0}
 --- !u!1 &1833241684301458
 GameObject:

--- a/Scripts/Data/Operation/TransformPropertyMutator.cs
+++ b/Scripts/Data/Operation/TransformPropertyMutator.cs
@@ -19,10 +19,10 @@
         [Tooltip("Determines whether to mutate the local or global values.")]
         public bool useLocalValues;
         /// <summary>
-        /// Determines which axes to lock and not mutate.
+        /// Determines which axes to mutate.
         /// </summary>
-        [Tooltip("Determines which axes to lock and not mutate.")]
-        public Vector3State lockAxis = Vector3State.False;
+        [Tooltip("Determines which axes to mutate.")]
+        public Vector3State mutateOnAxis = Vector3State.True;
 
         /// <summary>
         /// Sets the target.
@@ -50,7 +50,7 @@
         {
             if (!IsValid())
             {
-                return default(Vector3);
+                return default;
             }
 
             input = LockSetInput(input);
@@ -82,7 +82,7 @@
         {
             if (!IsValid())
             {
-                return default(Vector3);
+                return default;
             }
 
             input = LockIncrementInput(input);
@@ -103,58 +103,6 @@
         public virtual void DoIncrementProperty(Vector3 input)
         {
             IncrementProperty(input);
-        }
-
-        /// <summary>
-        /// Locks the set input based on the locked axes.
-        /// </summary>
-        /// <param name="input">The input to lock.</param>
-        /// <returns>The input locked on the required axes.</returns>
-        protected virtual Vector3 LockSetInput(Vector3 input)
-        {
-            input.x = (lockAxis.xState ? GetAxisValue(0) : input.x);
-            input.y = (lockAxis.yState ? GetAxisValue(1) : input.y);
-            input.z = (lockAxis.zState ? GetAxisValue(2) : input.z);
-            return input;
-        }
-
-        /// <summary>
-        /// Locks the increment input based on the locked axes.
-        /// </summary>
-        /// <param name="input">The input to lock.</param>
-        /// <returns>The input locked on the required axes.</returns>
-        protected virtual Vector3 LockIncrementInput(Vector3 input)
-        {
-            input.x = (lockAxis.xState ? 0f : input.x);
-            input.y = (lockAxis.yState ? 0f : input.y);
-            input.z = (lockAxis.zState ? 0f : input.z);
-            return input;
-        }
-
-        /// <summary>
-        /// Gets the value for a given axis.
-        /// </summary>
-        /// <param name="axis">The axis to get the value from.</param>
-        /// <returns>The axis value.</returns>
-        protected virtual float GetAxisValue(int axis)
-        {
-            if (useLocalValues)
-            {
-                return GetLocalAxisValue(axis);
-            }
-            else
-            {
-                return GetGlobalAxisValue(axis);
-            }
-        }
-
-        /// <summary>
-        /// Determines if the process is valid.
-        /// </summary>
-        /// <returns><see langword="true"/> if it is valid.</returns>
-        protected virtual bool IsValid()
-        {
-            return (isActiveAndEnabled && target != null);
         }
 
         /// <summary>
@@ -193,5 +141,57 @@
         /// <param name="axis">The axis to get the value from.</param>
         /// <returns>The axis value.</returns>
         protected abstract float GetGlobalAxisValue(int axis);
+
+        /// <summary>
+        /// Locks the set input based on the locked axes.
+        /// </summary>
+        /// <param name="input">The input to lock.</param>
+        /// <returns>The input locked on the required axes.</returns>
+        protected virtual Vector3 LockSetInput(Vector3 input)
+        {
+            input.x = mutateOnAxis.xState ? input.x : GetAxisValue(0);
+            input.y = mutateOnAxis.yState ? input.y : GetAxisValue(1);
+            input.z = mutateOnAxis.zState ? input.z : GetAxisValue(2);
+            return input;
+        }
+
+        /// <summary>
+        /// Locks the increment input based on the locked axes.
+        /// </summary>
+        /// <param name="input">The input to lock.</param>
+        /// <returns>The input locked on the required axes.</returns>
+        protected virtual Vector3 LockIncrementInput(Vector3 input)
+        {
+            input.x = mutateOnAxis.xState ? input.x : 0f;
+            input.y = mutateOnAxis.yState ? input.y : 0f;
+            input.z = mutateOnAxis.zState ? input.z : 0f;
+            return input;
+        }
+
+        /// <summary>
+        /// Gets the value for a given axis.
+        /// </summary>
+        /// <param name="axis">The axis to get the value from.</param>
+        /// <returns>The axis value.</returns>
+        protected virtual float GetAxisValue(int axis)
+        {
+            if (useLocalValues)
+            {
+                return GetLocalAxisValue(axis);
+            }
+            else
+            {
+                return GetGlobalAxisValue(axis);
+            }
+        }
+
+        /// <summary>
+        /// Determines if the process is valid.
+        /// </summary>
+        /// <returns><see langword="true"/> if it is valid.</returns>
+        protected virtual bool IsValid()
+        {
+            return (isActiveAndEnabled && target != null);
+        }
     }
 }

--- a/Tests/Editor/Data/Operation/TransformEulerRotationMutatorTest.cs
+++ b/Tests/Editor/Data/Operation/TransformEulerRotationMutatorTest.cs
@@ -32,7 +32,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
 
             Assert.AreEqual(Vector3.zero, target.transform.localEulerAngles);
 
@@ -51,7 +51,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
 
             Assert.AreEqual(Vector3.zero, target.transform.eulerAngles);
 
@@ -70,7 +70,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = new Vector3State(false, true, false);
+            subject.mutateOnAxis = new Vector3State(true, false, true);
 
             Assert.AreEqual(Vector3.zero, target.transform.localEulerAngles);
 
@@ -91,7 +91,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = new Vector3State(true, false, true);
+            subject.mutateOnAxis = new Vector3State(false, true, false);
 
             Assert.AreEqual(Vector3.zero, target.transform.eulerAngles);
 
@@ -112,7 +112,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
 
             Assert.AreEqual(Vector3.zero, target.transform.localEulerAngles);
 
@@ -135,7 +135,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
 
             Assert.AreEqual(Vector3.zero, target.transform.eulerAngles);
 
@@ -158,7 +158,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = new Vector3State(false, true, false);
+            subject.mutateOnAxis = new Vector3State(true, false, true);
 
             Assert.AreEqual(Vector3.zero, target.transform.localEulerAngles);
 
@@ -183,7 +183,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = new Vector3State(true, false, true);
+            subject.mutateOnAxis = new Vector3State(false, true, false);
 
             Assert.AreEqual(Vector3.zero, target.transform.eulerAngles);
 
@@ -208,7 +208,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
             subject.gameObject.SetActive(false);
 
             Assert.AreEqual(Vector3.zero, target.transform.eulerAngles);
@@ -228,7 +228,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
             subject.enabled = false;
 
             Assert.AreEqual(Vector3.zero, target.transform.eulerAngles);

--- a/Tests/Editor/Data/Operation/TransformPositionMutatorTest.cs
+++ b/Tests/Editor/Data/Operation/TransformPositionMutatorTest.cs
@@ -32,7 +32,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
 
             Assert.AreEqual(Vector3.zero, target.transform.localPosition);
 
@@ -51,7 +51,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
 
             Assert.AreEqual(Vector3.zero, target.transform.position);
 
@@ -70,7 +70,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = new Vector3State(false, true, false);
+            subject.mutateOnAxis = new Vector3State(true, false, true);
 
             Assert.AreEqual(Vector3.zero, target.transform.localPosition);
 
@@ -91,7 +91,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = new Vector3State(true, false, true);
+            subject.mutateOnAxis = new Vector3State(false, true, false);
 
             Assert.AreEqual(Vector3.zero, target.transform.position);
 
@@ -112,7 +112,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
 
             Assert.AreEqual(Vector3.zero, target.transform.localPosition);
 
@@ -135,7 +135,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
 
             Assert.AreEqual(Vector3.zero, target.transform.position);
 
@@ -158,7 +158,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = new Vector3State(false, true, false);
+            subject.mutateOnAxis = new Vector3State(true, false, true);
 
             Assert.AreEqual(Vector3.zero, target.transform.localPosition);
 
@@ -183,7 +183,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = new Vector3State(true, false, true);
+            subject.mutateOnAxis = new Vector3State(false, true, false);
 
             Assert.AreEqual(Vector3.zero, target.transform.position);
 
@@ -210,7 +210,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
             subject.rotationOffset = offset;
 
             Assert.AreEqual(Vector3.zero, target.transform.localPosition);
@@ -234,7 +234,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
             subject.rotationOffset = offset;
 
             Assert.AreEqual(Vector3.zero, target.transform.position);
@@ -258,7 +258,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = new Vector3State(false, true, false);
+            subject.mutateOnAxis = new Vector3State(true, false, true);
             subject.rotationOffset = offset;
 
             Assert.AreEqual(Vector3.zero, target.transform.localPosition);
@@ -283,7 +283,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = new Vector3State(true, false, true);
+            subject.mutateOnAxis = new Vector3State(false, true, false);
             subject.rotationOffset = offset;
 
             Assert.AreEqual(Vector3.zero, target.transform.position);
@@ -308,7 +308,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
             subject.rotationOffset = offset;
 
             Assert.AreEqual(Vector3.zero, target.transform.localPosition);
@@ -339,7 +339,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
             subject.rotationOffset = offset;
 
             Assert.AreEqual(Vector3.zero, target.transform.position);
@@ -369,7 +369,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = new Vector3State(false, true, false);
+            subject.mutateOnAxis = new Vector3State(true, false, true);
             subject.rotationOffset = offset;
 
             Assert.AreEqual(Vector3.zero, target.transform.localPosition);
@@ -400,7 +400,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = false;
-            subject.lockAxis = new Vector3State(true, false, true);
+            subject.mutateOnAxis = new Vector3State(false, true, false);
             subject.rotationOffset = offset;
 
             Assert.AreEqual(Vector3.zero, target.transform.position);
@@ -429,7 +429,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
             subject.gameObject.SetActive(false);
 
             Assert.AreEqual(Vector3.zero, target.transform.position);
@@ -449,7 +449,7 @@ namespace Test.VRTK.Core.Data.Operation
 
             subject.target = target;
             subject.useLocalValues = true;
-            subject.lockAxis = Vector3State.False;
+            subject.mutateOnAxis = Vector3State.True;
             subject.enabled = false;
 
             Assert.AreEqual(Vector3.zero, target.transform.position);


### PR DESCRIPTION
The TransformPropertyMutator had a Vector3State called `lockAxis` which
had the negative connotation that any checked box would not perform the
mutation on the axis. Other uses are positive connotations i.e. the
checked axis box means an operation **would** be performed on that
axis.

The `lockAxis` field has been changed for a `mutateOnAxis` field which
uses the positive connotation of any checked box will be mutated.

The prefabs that used the TransformPropertyMutators have also been
updated so the logic is flipped.